### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ secrets.yml
 users.yml
 extra_vars.yml
 *.txt
-.vagrant/*
+*.vagrant
 TODO
 TODO.md
 bak/


### PR DESCRIPTION
The .gitignore file can be used to cause git to not try and add ".vagrant" in the future

Signed-off-by: Phil Huang <phil.huang@redhat.com>