### PR TITLE
Re-order network workshop and training decks first

### DIFF
--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -237,16 +237,16 @@ $("document").ready(function(){
         </div>
 
         <div class="row">
+          <div class="col-sm-4">
+              <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/networking/">Ansible Networking Workshop</a>
+          </div>
+
             <div class="col-sm-4">
                 <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/ansible_engine/">Ansible Engine Workshop</a>
             </div>
 
             <div class="col-sm-4">
                 <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/ansible_tower/">Ansible Tower Workshop</a>
-            </div>
-
-            <div class="col-sm-4">
-                <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/networking/">Ansible Networking Workshop</a>
             </div>
 
         </div>
@@ -265,16 +265,16 @@ $("document").ready(function(){
         </div>
 
         <div class="row">
+          <div class="col-sm-4">
+              <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/decks/ansible-networking.html">Ansible Networking</a>
+          </div>
+
             <div class="col-sm-4">
                 <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/decks/ansible-essentials.html">Ansible Essentials</a>
             </div>
 
             <div class="col-sm-4">
                 <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/decks/intro-to-ansible-tower.html">Intro To Ansible Tower</a>
-            </div>
-
-            <div class="col-sm-4">
-                <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/decks/ansible-networking.html">Ansible Networking</a>
             </div>
 
         </div>


### PR DESCRIPTION
 Change the order in the index.html.jinja2 so that the networking
labs and networking decks appear first in order (since this is
the networking linklight repo.)

Built and tested.

Issue: #47