### PR TITLE
Add note about boto3 no-worky with env variables.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,3 +37,10 @@ Set your Access Key ID and Secret Access Key under ~/.aws/credentials
 aws_access_key_id = ABCDEFGHIJKLMNOP
 aws_secret_access_key = ABCDEFGHIJKLMNOP/ABCDEFGHIJKLMNOP
 ```
+
+<aside class="warning">
+NOTE: boto3 (the AWS python library) doesn't properly handle AwS environment variables and will generate a fairly opaque parsing error. Stick with the credentials file shown above or something similar. The error is something like:
+</aside>
+```
+caught_exception\nValueError: Invalid header value 'AWS4-HMAC-SHA256 ...
+```


### PR DESCRIPTION
 boto3 can't properly munge/manufacture URIs based on
the default/normal AWS environment variable settings. It
works fine however with the ~/.aws/credentials files with
THE EXACT SAME VALUES.

Issue: #54