### PR TITLE
Fixed idempotency on exercises/networking/1.3-gre

### DIFF
--- a/exercises/networking/1.3-gre/gre.yml
+++ b/exercises/networking/1.3-gre/gre.yml
@@ -18,7 +18,7 @@
        - 'ip address 10.0.0.1 255.255.255.0'
        - 'tunnel source GigabitEthernet1'
        - 'tunnel destination {{rtr2_public_ip}}'
-      parents: interface Tunnel 0
+      parents: interface Tunnel0
     when:
       - '"rtr1" in inventory_hostname'
 
@@ -28,6 +28,6 @@
        - 'ip address 10.0.0.2 255.255.255.0'
        - 'tunnel source GigabitEthernet1'
        - 'tunnel destination {{rtr1_public_ip}}'
-      parents: interface Tunnel 0
+      parents: interface Tunnel0
     when:
       - '"rtr2" in inventory_hostname'

--- a/exercises/networking/1.3-gre/rollback_gre.yml
+++ b/exercises/networking/1.3-gre/rollback_gre.yml
@@ -8,5 +8,5 @@
   tasks:
   - name: teardown tunnel interface to R2
     ios_interface:
-      name: interface tunnel 0
+      name: Tunnel0
       state: absent


### PR DESCRIPTION
Making sure the playbooks are idempotent. 

> ios_config expects the lines to match what is in the output of "show running-config" otherwise it assumes it is changed

