### PR TITLE
Update resources.yml

### DIFF
--- a/provisioner/roles/manage_ec2_instances/tasks/resources.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/resources.yml
@@ -45,6 +45,14 @@
         to_port: 22
         from_port: 22
         cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        to_port: 8888
+        from_port: 8888
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        to_port: 8080
+        from_port: 8080
+        cidr_ip: 0.0.0.0/0
     rules_egress:
       - proto: all
         cidr_ip: 0.0.0.0/0


### PR DESCRIPTION
Updated to allow 8888 and 8080 to be used with Wetty for workshops that do not allow access to AWS.

Tested and this is working.