### PR TITLE
 a little typo of markdown

### DIFF
--- a/exercises/networking_v2/labs/lab01-network-facts/exercise02-first-playbook/README.md
+++ b/exercises/networking_v2/labs/lab01-network-facts/exercise02-first-playbook/README.md
@@ -21,6 +21,7 @@ Using your favorite text editor (`vim` and `nano` are available on the control h
 Enter the following play definition into `gather_ios_data.yml`:
 
 >Press the letter "i" to enter insert mode*
+
 ``` yaml
 ---
 - name: GATHER INFORMATION FROM ROUTERS


### PR DESCRIPTION
The range of the blockquote is incorrect. 
There is no problem when looking at [github.com](https://github.com/network-automation/linklight/tree/master/exercises/networking_v2/labs/lab01-network-facts/exercise02-first-playbook), but there is a problem when looking at [GitHub Pages](https://network-automation.github.io/linklight/exercises/networking_v2/labs/lab01-network-facts/exercise02-first-playbook/).

So, inserted new line.

