### PR TITLE
Using version comparison test to check boto3 version

### DIFF
--- a/provisioner/roles/aws_check_setup/tasks/main.yml
+++ b/provisioner/roles/aws_check_setup/tasks/main.yml
@@ -6,7 +6,8 @@
 - name: make sure we are running correct boto version
   assert:
     that:
-    - py_cmd.stdout.startswith('1.7')
+      - py_cmd.stdout is version('1.7', operator='ge')
+    msg: "boto3 >= 1.7 is required."
 
 - name: check for underscores in workshop name
   fail:


### PR DESCRIPTION
boto3 >= 1.7 requirement is now checked via a version comparison test, instead of the hard "starts with" that was used before. 