### PR TITLE
Update documentation for setting Route53 zone

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -68,7 +68,7 @@ If you used `create_login_page: true` above you will also get a webpage created 
 The webpage will be generated as {{ec2_name_prefix}}.rhdemo.io
 in the example above this literally means http://testworkshop.rhdemo.io
 
-It is possible to change the route53 DNS as well.
+It is possible to change the route53 DNS as well using the parameter `workshop_dns_zone` in your `extra_vars.yml` file.
 
 # Remote Desktop
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -70,6 +70,8 @@ in the example above this literally means http://testworkshop.rhdemo.io
 
 It is possible to change the route53 DNS as well using the parameter `workshop_dns_zone` in your `extra_vars.yml` file.
 
+This playbook does not create the route53 zone and must exist prior to running the playbook.
+
 # Remote Desktop
 
 If you used `xrdp: true` you will the ability to remote desktop to the control node.

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -33,8 +33,9 @@ student_total: 2                       # creates student_total of workbenches fo
 admin_password: ansible                # password for Ansible control node, defaults to ansible
 networking: true                       # Set this if you want the workshop in networking mode
 create_login_page: true                # creates AWS S3 website for ec2_name_prefix.workshop_dns_zone
+workshop_dns_zone: rhdemo.io           # Sets the Route53 DNS zone to use for the S3 website
 towerinstall: true                     # automatically installs Tower to control node
-#autolicense: true                    # automatically licenses Tower if license is provided
+#autolicense: true                     # automatically licenses Tower if license is provided
 #xrdp: true                            # install xrdp with xfce for graphical interface
 ```
 


### PR DESCRIPTION
This is just some edits to the documentation to help make users more aware of the `workshop_dns_zone` parameter.