### PR TITLE
Add custom_key option

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -37,6 +37,7 @@ workshop_dns_zone: rhdemo.io           # Sets the Route53 DNS zone to use for th
 towerinstall: true                     # automatically installs Tower to control node
 #autolicense: true                     # automatically licenses Tower if license is provided
 #xrdp: true                            # install xrdp with xfce for graphical interface
+#custom_key: <aws keypair name>        # use an existing keypair
 ```
 
 If you want to license it you must copy a license called tower_license.json into this directory.  If you do not have a license already please request one using the [Workshop License Link](https://www.ansible.com/workshop-license).

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -38,6 +38,7 @@ towerinstall: true                     # automatically installs Tower to control
 #autolicense: true                     # automatically licenses Tower if license is provided
 #xrdp: true                            # install xrdp with xfce for graphical interface
 #custom_key: <aws keypair name>        # use an existing keypair
+#ansible_ssh_private_key_file          # this variable is required when using custom_key
 ```
 
 If you want to license it you must copy a license called tower_license.json into this directory.  If you do not have a license already please request one using the [Workshop License Link](https://www.ansible.com/workshop-license).

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -120,6 +120,17 @@
   roles:
     - { role: f5_setup, when: f5workshop }
 
+- name: ROUTER COMMON CONFIG
+  hosts: routers
+  become: yes
+  connection: network_cli
+  gather_facts: no
+
+  tasks:
+  - include_role:
+      name: configure_routers
+      tasks_from: add_user
+
 - name: GATHER AWS FACTS FOR ROUTERS
   hosts: access,core
   connection: local

--- a/provisioner/roles/configure_routers/tasks/add_user.yml
+++ b/provisioner/roles/configure_routers/tasks/add_user.yml
@@ -1,0 +1,5 @@
+---
+- ios_user:
+    name: "{{ username }}"
+    configured_password: "{{ admin_password }}"
+    privilege: 15

--- a/provisioner/roles/control_node/tasks/networking.yml
+++ b/provisioner/roles/control_node/tasks/networking.yml
@@ -65,21 +65,21 @@
     group: "{{ username }}"
     state: directory
 
-- name: Put ssh-key in proper spot for student
-  copy:
-    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
-    dest: "/home/{{username}}/.ssh/aws-private.pem"
-    owner: "{{ username }}"
-    group: "{{ username }}"
-    mode: 0400
-
-- name: Put ssh-key in proper for {{ansible_user}}
-  copy:
-    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
-    dest: "/home/{{ansible_user}}/.ssh/aws-private.pem"
-    owner: "{{ansible_user}}"
-    group: "{{ansible_user}}"
-    mode: 0400
+#- name: Put ssh-key in proper spot for student
+#  copy:
+#    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+#    dest: "/home/{{username}}/.ssh/aws-private.pem"
+#    owner: "{{ username }}"
+#    group: "{{ username }}"
+#    mode: 0400
+#
+#- name: Put ssh-key in proper for {{ansible_user}}
+#  copy:
+#    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+#    dest: "/home/{{ansible_user}}/.ssh/aws-private.pem"
+#    owner: "{{ansible_user}}"
+#    group: "{{ansible_user}}"
+#    mode: 0400
 
 - name: copy over ssh config file for student
   template:

--- a/provisioner/roles/control_node/templates/ansible.cfg.j2
+++ b/provisioner/roles/control_node/templates/ansible.cfg.j2
@@ -10,6 +10,4 @@ inventory = /home/{{ username }}/networking-workshop/lab_inventory/hosts
 inventory = /home/{{ username }}/lightbulb/lessons/lab_inventory/{{username}}-instances.txt
 {% endif %}
 host_key_checking = False
-{% if networking is defined %}
-private_key_file = /home/{{ username }}/.ssh/aws-private.pem
-{% endif %}
+retry_files_enabled = False

--- a/provisioner/roles/manage_ec2_instances/tasks/addhost_engine.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/addhost_engine.yml
@@ -36,6 +36,22 @@
     - "{{ node2_node_facts.instances }}"
     - "{{ node3_node_facts.instances }}"
   changed_when: no
+  when: custom_key is not defined
+
+- name: add hosts to groups (ANSIBLE ESSENTIALS MODE) - custom key
+  add_host:
+    name: "{{ item.tags.Name }}"
+    short_name: "{{ item.tags.short_name }}"
+    ansible_host: "{{ item.public_ip_address }}"
+    ansible_user: "{{ ec2_login_names[node1_node] }}"
+    ansible_port: "{{ ssh_port }}"
+    groups: lab_hosts,managed_nodes
+  with_items:
+    - "{{ node1_node_facts.instances }}"
+    - "{{ node2_node_facts.instances }}"
+    - "{{ node3_node_facts.instances }}"
+  changed_when: no
+  when: custom_key is defined
 
 - name: Generate student inventories
   template:

--- a/provisioner/roles/manage_ec2_instances/tasks/addhost_f5.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/addhost_f5.yml
@@ -19,6 +19,21 @@
     groups:
       - f5
   with_items: "{{ f5_node_facts.instances }}"
+  when: custom_key is not defined
+
+- name: add f5 to groups (F5 MODE) - custom key
+  add_host:
+    name: "{{ item.tags.Name }}"
+    short_name: "{{ item.tags.short_name }}"
+    ansible_host: "{{ item.public_ip_address }}"
+    ansible_user: admin
+    ansible_password: admin
+    ansible_port: "{{ ssh_port }}"
+    private_ip: "{{item.private_ip_address}}"
+    groups:
+      - f5
+  with_items: "{{ f5_node_facts.instances }}"
+  when: custom_key is defined
 
 - name: grab facts for host1 node (F5 MODE)
   ec2_instance_facts:
@@ -41,6 +56,22 @@
       - lab_hosts
       - managed_nodes
   with_items: "{{ host1_node_facts.instances }}"
+  when: custom_key is not defined
+
+- name: add host1 to groups (NETWORKING MODE) - custom key
+  add_host:
+    name: "{{ item.tags.Name }}"
+    short_name: "{{ item.tags.short_name }}"
+    ansible_host: "{{ item.public_ip_address }}"
+    ansible_user: "{{ ec2_login_names[ansible_node] }}"
+    ansible_port: "{{ ssh_port }}"
+    ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    private_ip: "{{item.private_ip_address}}"
+    groups:
+      - lab_hosts
+      - managed_nodes
+  with_items: "{{ host1_node_facts.instances }}"
+  when: custom_key is defined
 
 - name: grab facts for host2 node (F5 MODE)
   ec2_instance_facts:
@@ -63,6 +94,22 @@
       - lab_hosts
       - managed_nodes
   with_items: "{{ host2_node_facts.instances }}"
+  when: custom_key is not defined
+
+- name: add host2 to groups (NETWORKING MODE) - custom key
+  add_host:
+    name: "{{ item.tags.Name }}"
+    short_name: "{{ item.tags.short_name }}"
+    ansible_host: "{{ item.public_ip_address }}"
+    ansible_user: "{{ ec2_login_names[ansible_node] }}"
+    ansible_port: "{{ ssh_port }}"
+    ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    private_ip: "{{item.private_ip_address}}"
+    groups:
+      - lab_hosts
+      - managed_nodes
+  with_items: "{{ host2_node_facts.instances }}"
+  when: custom_key is defined
 
 - name: Generate student inventories
   template:

--- a/provisioner/roles/manage_ec2_instances/tasks/addhost_networking.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/addhost_networking.yml
@@ -37,6 +37,41 @@
       "tag:Workshop_rtr2": "{{ec2_name_prefix}}-rtr2"
   register: rtr2_node_facts
 
+- name: ADD ROUTERS TO INVENTORY
+  add_host:
+    name: "{{ item.tags.Name }}"
+    short_name: "{{ item.tags.short_name }}"
+    ansible_host: "{{ item.public_ip_address }}"
+    username: "{{ item.tags.Student }}"
+    ansible_user: ec2-user
+    ansible_port: "{{ ssh_port }}"
+    ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    private_ip: "{{item.private_ip_address}}"
+    ansible_network_os: ios
+    groups:
+      - routers
+  with_items:
+    - "{{ rtr1_node_facts.instances }}"
+    - "{{ rtr2_node_facts.instances }}"
+  when: custom_key is not defined
+
+- name: ADD ROUTERS TO INVENTORY
+  add_host:
+    name: "{{ item.tags.Name }}"
+    short_name: "{{ item.tags.short_name }}"
+    ansible_host: "{{ item.public_ip_address }}"
+    username: "{{ item.tags.Student }}"
+    ansible_user: ec2-user
+    ansible_port: "{{ ssh_port }}"
+    private_ip: "{{item.private_ip_address}}"
+    ansible_network_os: ios
+    groups:
+      - routers
+  with_items:
+    - "{{ rtr1_node_facts.instances }}"
+    - "{{ rtr2_node_facts.instances }}"
+  when: custom_key is defined
+
 - name: addhosts for rtr3 and rtr4 in special mode
   block:
   ##### Router 3 ####

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_engine.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_engine.yml
@@ -22,7 +22,7 @@
 - name: Create EC2 instances for node1
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types[node1_node].size }}"
     image: "{{ node1_ami.image_id }}"
@@ -76,7 +76,7 @@
 - name: Create EC2 instances for node2
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types[node2_node].size }}"
     image: "{{ node2_ami.image_id }}"
@@ -130,7 +130,7 @@
 - name: Create EC2 instances for node3
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types[node3_node].size }}"
     image: "{{ node3_ami.image_id }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_engine.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_engine.yml
@@ -54,6 +54,7 @@
       Info: "Username that provisioned this-> {{ linklight_user }}"
       Linklight: "This was provisioned through the linklight provisioner"
       Students: "{{student_total}}"
+      Platform: "linux"
       short_name: "node1"
   with_indexed_items:
     - "{{ node1_output.instance_ids }}"
@@ -108,6 +109,7 @@
       Info: "Username that provisioned this-> {{ linklight_user }}"
       Linklight: "This was provisioned through the linklight provisioner"
       Students: "{{student_total}}"
+      Platform: "linux"
       short_name: "node2"
   with_indexed_items:
     - "{{ node2_output.instance_ids }}"
@@ -162,6 +164,7 @@
       Info: "Username that provisioned this-> {{ linklight_user }}"
       Linklight: "This was provisioned through the linklight provisioner"
       Students: "{{student_total}}"
+      Platform: "linux"
       short_name: "node3"
   with_indexed_items:
     - "{{ node3_output.instance_ids }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_f5.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_f5.yml
@@ -16,7 +16,7 @@
 - name: Create EC2 instances for f5 node (F5 MODE)
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types.f5node.size }}"
     image: "{{ f5_ami.image_id }}"
@@ -65,7 +65,7 @@
 - name: Create EC2 instances for host1 node in VPC (F5 MODE)
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types.rhel7.size }}"
     image: "{{ host1_ami.image_id }}"
@@ -100,7 +100,7 @@
 - name: Create EC2 instances for host2 node in VPC (F5 MODE)
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types.rhel7.size }}"
     image: "{{ host1_ami.image_id }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_f5_OLD.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_f5_OLD.yml
@@ -10,7 +10,7 @@
     Vpc: "{{ec2_vpc_id}}"
     restrictedSrcAddress: "0.0.0.0/0"
     restrictedSrcAddressApp: "0.0.0.0/0"
-    sshKey: "{{ ec2_name_prefix }}-key"
+    sshKey: "{{ ec2_key_name }}"
     imageName: "Good25Mbps"
    validate_certs: "no"
    tags:
@@ -46,7 +46,7 @@
 - name: Create EC2 instances for host1 node in VPC (F5 MODE)
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types.rhel7.size }}"
     image: "{{ host1_ami.image_id }}"
@@ -81,7 +81,7 @@
 - name: Create EC2 instances for host2 node in VPC (F5 MODE)
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types.rhel7.size }}"
     image: "{{ host1_ami.image_id }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_networking.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_networking.yml
@@ -66,6 +66,7 @@
       Info: "Username that provisioned this-> {{ linklight_user }}"
       Linklight: "This was provisioned through the linklight provisioner"
       Students: "{{student_total}}"
+      Platform: "ios"
       short_name: "rtr1"
   with_indexed_items:
     - "{{ rtr1_output.instance_ids }}"
@@ -119,6 +120,7 @@
       Info: "Username that provisioned this-> {{ linklight_user }}"
       Linklight: "This was provisioned through the linklight provisioner"
       Students: "{{student_total}}"
+      Platform: "ios"
       short_name: "rtr2"
   with_indexed_items:
     - "{{ rtr2_output.instance_ids }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_networking.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_networking.yml
@@ -39,7 +39,7 @@
 - name: Create EC2 instances for rtr1 node (NETWORKING MODE)
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types[rtr1_node].size }}"
     image: "{{ rtr1_ami.image_id }}"
@@ -92,7 +92,7 @@
 - name: Create EC2 instances for rtr2 node in VPC-2 (NETWORKING MODE)
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group2 }}"
     instance_type: "{{ ec2_instance_types[rtr2_node].size }}"
     image: "{{ rtr2_ami.image_id }}"
@@ -144,7 +144,7 @@
   - name: Create EC2 instances for rtr3 node (NETWORKING MODE)
     ec2:
       assign_public_ip: yes
-      key_name: "{{ ec2_name_prefix }}-key"
+      key_name: "{{ ec2_key_name }}"
       group: "{{ ec2_security_group }}"
       instance_type: "{{ ec2_instance_types[rtr3_node].size }}"
       image: "{{ rtr3_ami.image_id }}"
@@ -196,7 +196,7 @@
   - name: Create EC2 instances for rtr4 node in VPC-2 (NETWORKING MODE)
     ec2:
       assign_public_ip: yes
-      key_name: "{{ ec2_name_prefix }}-key"
+      key_name: "{{ ec2_key_name }}"
       group: "{{ ec2_security_group2 }}"
       instance_type: "{{ ec2_instance_types[rtr4_node].size }}"
       image: "{{ rtr4_ami.image_id }}"
@@ -246,7 +246,7 @@
 - name: Create EC2 instances for host1 node in VPC-2 (NETWORKING MODE)
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group2 }}"
     instance_type: "{{ ec2_instance_types[host1_node].size }}"
     image: "{{ host1_ami.image_id }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/provision.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/provision.yml
@@ -35,7 +35,7 @@
 - name: Create EC2 instances for ansible node (control node)
   ec2:
     assign_public_ip: yes
-    key_name: "{{ ec2_name_prefix }}-key"
+    key_name: "{{ ec2_key_name }}"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_types[ansible_node].size }}"
     image: "{{ ansible_control_node_ami.image_id }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/provision.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/provision.yml
@@ -67,6 +67,7 @@
       Info: "Username that provisioned this-> {{ linklight_user }}"
       Linklight: "This was provisioned through the linklight provisioner"
       Students: "{{student_total}}"
+      Platform: "linux"
       short_name: "ansible"
   with_indexed_items:
     - "{{ control_output.instance_ids }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/resources.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/resources.yml
@@ -143,7 +143,13 @@
 
 - name: set key name
   set_fact:
-    ec2_key_name: "{{ custom_key | default(create_key.key.name) }}"
+    ec2_key_name: "{{ create_key.key.name }}"
+  when: custom_key is not defined
+
+- name: set custom key name
+  set_fact:
+    ec2_key_name: "{{ custom_key }}"
+  when: custom_key is defined
 
 - name: debugging all variables for ec2 instance creation VPC-1
   debug:

--- a/provisioner/roles/manage_ec2_instances/tasks/resources.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/resources.yml
@@ -132,13 +132,18 @@
     name: "{{ ec2_name_prefix }}-key"
     region: "{{ ec2_region }}"
   register: create_key
+  when: custom_key is not defined
 
 - name: save private key
   copy:
     content: "{{ create_key.key.private_key }}"
     dest: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
     mode: '0400'
-  when: create_key.changed
+  when: custom_key is not defined and create_key.changed
+
+- name: set key name
+  set_fact:
+    ec2_key_name: "{{ custom_key | default(create_key.key.name) }}"
 
 - name: debugging all variables for ec2 instance creation VPC-1
   debug:

--- a/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
@@ -157,12 +157,14 @@
 - name: set keys for instance creation dynamically since key was not supplied by user
   set_fact:
     ec2_key_name: "{{ ec2_name_prefix }}-key"
+  when: custom_key is not defined
 
 - name: delete ssh key pair for workshop {{ ec2_name_prefix }}
   ec2_key:
     name: "{{ec2_key_name}}"
     region: "{{ ec2_region }}"
     state: absent
+  when: custom_key is not defined
 
 - name: delete AWS VPC {{ ec2_name_prefix }}
   ec2_vpc_net:

--- a/provisioner/roles/manage_ec2_instances/templates/networking_instances.txt.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/networking_instances.txt.j2
@@ -1,4 +1,6 @@
 [all:vars]
+ansible_user=student{{ item }}
+ansible_ssh_pass={{ admin_password }}
 {% if ssh_port is defined %}
 ansible_port={{ ssh_port }}
 {% endif %}
@@ -48,7 +50,6 @@ juniper
 {% endif %}
 
 [cisco:vars]
-ansible_user=ec2-user
 ansible_network_os=ios
 
 {% if special is defined and special == "multivendor" %}
@@ -72,7 +73,7 @@ rtr4
 [hosts]
 {% for vm in host1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.tags.Name | regex_replace('.*-([\\w]*)', '\\1') }} ansible_host={{ vm.public_ip_address }} ansible_user={{ ec2_login_names[host1_node] }} private_ip={{ vm.private_ip_address }}
+{{ vm.tags.Name | regex_replace('.*-([\\w]*)', '\\1') }} ansible_host={{ vm.public_ip_address }} private_ip={{ vm.private_ip_address }}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Add variable `custom_key` to specify an existing AWS keypair rather than creating one. Makes it easier to use provisioner from Tower, in dynamic inventories, and for demo environments.

Also changes networking lab to user username/pass for authentication into routers. This removes the requirement for the key to be copied to the student's control node. 

This has been tested with linux lightbulb and networking link light. Does not apply to f5 and special.