### PR TITLE
feature branch commit for juniper + cisco

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -138,6 +138,7 @@
         type: csr_access
         router3_tunnel: 100
         router4_tunnel: 101
+      when: special is match("all_cisco")
 
 - name: CONFIGURE CORE ROUTERS
   hosts: core
@@ -151,6 +152,7 @@
         router1_tunnel: 100
         router2_tunnel: 101
         dci_tunnel: 200
+      when: special is match("all_cisco")
 
 - name: CONFIGURE CORE ROUTERS
   hosts: dmvpn
@@ -161,6 +163,7 @@
     - role: configure_routers
       vars:
         type: csr_hub
+      when: special is match("all_cisco")
 
 - name: Alert the mothership
   hosts: localhost

--- a/provisioner/roles/control_node/templates/ansible.cfg.j2
+++ b/provisioner/roles/control_node/templates/ansible.cfg.j2
@@ -10,6 +10,3 @@ inventory = /home/{{ username }}/networking-workshop/lab_inventory/hosts
 inventory = /home/{{ username }}/lightbulb/lessons/lab_inventory/{{username}}-instances.txt
 {% endif %}
 host_key_checking = False
-{% if networking is defined %}
-private_key_file = /home/{{ username }}/.ssh/aws-private.pem
-{% endif %}

--- a/provisioner/roles/control_node/templates/sshconfig.j2
+++ b/provisioner/roles/control_node/templates/sshconfig.j2
@@ -1,3 +1,11 @@
+{% if special is defined %}
+{% if special is match("multivendor") %}
+Host rtr3 rtr4
+     StrictHostKeyChecking no
+     User jnpr
+     IdentityFile /home/student1/.ssh/aws-private.pem
+{% endif %}
+{% endif %}
 Host *
      StrictHostKeyChecking no
      User {{ansible_user}}

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_networking.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_networking.yml
@@ -67,6 +67,7 @@
       Linklight: "This was provisioned through the linklight provisioner"
       Students: "{{student_total}}"
       short_name: "rtr1"
+      ansible_network_os: "{{ec2_instance_types[rtr1_node].os}}"
   with_indexed_items:
     - "{{ rtr1_output.instance_ids }}"
   when: rtr1_output.instance_ids is not none
@@ -120,6 +121,7 @@
       Linklight: "This was provisioned through the linklight provisioner"
       Students: "{{student_total}}"
       short_name: "rtr2"
+      ansible_network_os: "{{ec2_instance_types[rtr2_node].os}}"
   with_indexed_items:
     - "{{ rtr2_output.instance_ids }}"
   when: rtr2_output.instance_ids is not none
@@ -172,6 +174,7 @@
         Linklight: "This was provisioned through the linklight provisioner"
         Students: "{{student_total}}"
         short_name: "rtr3"
+        ansible_network_os: "{{ec2_instance_types[rtr3_node].os}}"
     with_indexed_items:
       - "{{ rtr3_output.instance_ids }}"
     when: rtr3_output.instance_ids is not none
@@ -224,6 +227,7 @@
         Linklight: "This was provisioned through the linklight provisioner"
         Students: "{{student_total}}"
         short_name: "rtr4"
+        ansible_network_os: "{{ec2_instance_types[rtr4_node].os}}"
     with_indexed_items:
       - "{{ rtr4_output.instance_ids }}"
     when: rtr4_output.instance_ids is not none

--- a/provisioner/roles/manage_ec2_instances/templates/instructor_inventory_networking.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/instructor_inventory_networking.j2
@@ -12,23 +12,23 @@ ansible_port={{ ssh_port }}
 {% endfor %}
 {% for host in rtr1_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{{ host.tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ host.public_ip_address }} ansible_user={{ec2_login_names[rtr1_node] }}
+{{ host.tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ host.public_ip_address }} ansible_user={{ec2_login_names[rtr1_node] }} ansible_network_os={{ host.tags.ansible_network_os }}
 {% endif %}
 {% endfor %}
 {% for host in rtr2_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{{ host.tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ host.public_ip_address }} ansible_user={{ec2_login_names[rtr2_node] }}
+{{ host.tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ host.public_ip_address }} ansible_user={{ec2_login_names[rtr2_node] }} ansible_network_os={{ host.tags.ansible_network_os }}
 {% endif %}
 {% endfor %}
 {% if special is defined %}
 {% for host in rtr3_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{{ host.tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ host.public_ip_address }} ansible_user={{ec2_login_names[rtr3_node] }}
+{{ host.tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ host.public_ip_address }} ansible_user={{ec2_login_names[rtr3_node] }} ansible_network_os={{ host.tags.ansible_network_os }}
 {% endif %}
 {% endfor %}
 {% for host in rtr4_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{{ host.tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ host.public_ip_address }} ansible_user={{ec2_login_names[rtr4_node] }}
+{{ host.tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ host.public_ip_address }} ansible_user={{ec2_login_names[rtr4_node] }} ansible_network_os={{ host.tags.ansible_network_os }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/provisioner/roles/manage_ec2_instances/templates/networking_instances.txt.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/networking_instances.txt.j2
@@ -9,6 +9,9 @@ cisco
 juniper
 {% endif %}
 
+[routers:vars]
+ansible_ssh_private_key_file=/home/student{{item}}/.ssh/aws-private.pem
+
 [cisco]
 {% for vm in rtr1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
@@ -72,13 +75,13 @@ rtr4
 [hosts]
 {% for vm in host1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.tags.Name | regex_replace('.*-([\\w]*)', '\\1') }} ansible_host={{ vm.public_ip_address }} ansible_user={{ ec2_login_names[host1_node] }} private_ip={{ vm.private_ip_address }}
+{{ vm.tags.short_name }} ansible_host={{ vm.public_ip_address }} ansible_user={{ ec2_login_names[host1_node] }} private_ip={{ vm.private_ip_address }}
 {% endif %}
 {% endfor %}
 
 [control]
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.tags.Name | regex_replace('.*-([\\w]*)', '\\1') }} ansible_host={{ vm.public_ip_address }} ansible_user={{ ec2_login_names[ansible_node] }} private_ip={{ vm.private_ip_address }}
+{{ vm.tags.short_name }} ansible_host={{ vm.public_ip_address }} ansible_user={{ ec2_login_names[ansible_node] }} private_ip={{ vm.private_ip_address }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
(1) Adding sshconfig for juniper devices so that student can just ssh directly into juniper devices (rtr3 and rtr4) e.g.->

```
[student1@ansible ~]$ ssh rtr3
Warning: Permanently added 'rtr3,35.182.23.28' (ECDSA) to the list of known hosts.
--- JUNOS 17.4R1-S2.2 Kernel 64-bit  JNPR-11.0-20180127.fdc8dfc_buil

jnpr@ip-172-16-54-15>
```

(2) Making sure that ansible works "out of the box" for both cisco and juniper->

juniper->

```
[student1@ansible ~]$ ansible -m junos_netconf -c network_cli rtr3
rtr3 | CHANGED => {
    "changed": true,
    "commands": [
        "set system services netconf ssh port 830"
    ]
}
```

cisco csr->

```
[student1@ansible ~]$ ansible -m ios_facts -c network_cli rtr1
rtr1 | SUCCESS => {
    "ansible_facts": {
        "ansible_net_all_ipv4_addresses": [
            "172.16.223.71",
            "192.168.35.101"
        ],
```

(3) moving the SSH key to inventory vs the ansible.cfg so students understand better where the key is applied

(4) adding tag for ansible_network_os for AWS

(5) removing regex and using tag for short name