### PR TITLE
Provisioner checks for >= 2.7 and fails if not

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -14,7 +14,7 @@
 - [FAQ](../docs/faq.md)
 
 # Requirements
-- This provisioner must be run with Ansible Engine v2.6.0 or higher.
+- This provisioner must be run with Ansible Engine v2.7.0 or higher.
 - AWS Account (follow directions on one time setup below)
 
 # Lab Setup


### PR DESCRIPTION
Update requirements

##### SUMMARY
Fails to provision in 2.6.x must be running ansible >= 2.7
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
provisioner

##### ADDITIONAL INFORMATION
Ran into on a clean checkout this date and time.
