### PR TITLE
adding support for ansible 2.7.X, removing devel dependicies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,13 @@ The Ansible Networking Linklight project is intended for effectively demonstrati
   * [Presentation Decks](decks)  
      - [Ansible Essentials Deck](https://network-automation.github.io/linklight/decks/ansible-essentials.html)
      - [Intro to Ansible Tower Deck](https://network-automation.github.io/linklight/decks/tower_intro.pdf)
-     - [Ansible Networking Deck *Deprecated](https://network-automation.github.io/linklight/decks/ansible-networking.html#)
      - [Ansible Networking-v2 Deck](https://network-automation.github.io/linklight/decks/ansible_network.pdf)
      - [Ansible F5 Deck](https://network-automation.github.io/linklight/decks/ansible_f5.pdf)
 
   * Network Automation Exercises
     These exercises are focused on networking platforms like Arista, Cisco, Juniper and F5.
 
-     - [Ansible Networking Workshop Exercises *Deprecated](exercises/networking/README.md)
-     - [Ansible Networking-v2 Workshop Exercises](exercises/networking_v2/README.md)
+     - [Ansible Network Automation Workshop Exercises](exercises/networking_v2/README.md)
      - [Ansible F5 Workshop Exercises](exercises/ansible_f5/README.md)
 
   * Server Automation Exercises
@@ -37,9 +35,6 @@ The Ansible Networking Linklight project is intended for effectively demonstrati
 
 # Slack
 Do you like Slack?  So do we! [click to join our ansiblenetwork slack](https://join.slack.com/t/ansiblenetwork/shared_invite/enQtMzEyMTcxMTE5NjM3LWIyMmQ4YzNhYTA4MjA2OTRhZDQzMTZkNWZlN2E3NzhhMWQ5ZTdmNmViNjk2M2JkYzJjODhjMjVjMGUxZjc2MWE)
-
-# Mailing List
-Join our [mailing list](https://www.redhat.com/mailman/listinfo/linklight)
 
 ---
 ![Red Hat Ansible Automation](images/rh-ansible-automation.png)

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -8,7 +8,7 @@
       assert:
         that:
           - ansible_version.major >= 2
-          - ansible_version.minor >= 8
+          - ansible_version.minor >= 7
 
       # F5workshop and networking workshop are two different workshops
     - name: make sure f5workshop is not turned on when networking is

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -243,7 +243,7 @@ $("document").ready(function(){
         {% if networking %}
         <div class="row">
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/networking_v2/">Ansible Networking v2 Exercises</a>
+              <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/networking_v2/">Ansible Network Exercises</a>
           </div>
 
           <div class="col-sm-4">

--- a/provisioner/roles/control_node/tasks/networking.yml
+++ b/provisioner/roles/control_node/tasks/networking.yml
@@ -1,8 +1,3 @@
-- name: Clear out linklight directory spot (NETWORKING MODE)
-  file:
-    state: absent
-    path: /tmp/linklight
-
 - name: Clone linklight repo (NETWORKING MODE)
   git:
     accept_hostkey: yes
@@ -11,34 +6,41 @@
     repo: https://github.com/network-automation/linklight.git
     force: yes
 
-- name: for networking modes
-  block:
-    - name: Move networking workshop folder to correct location  (NETWORKING MODE)
-      copy:
-        src: /tmp/linklight/exercises/networking/
-        dest: /home/{{ username }}/networking-workshop
-        remote_src: yes
-      when: special is not defined
-
-    - name: Move networking workshop folder to correct location  (NETWORKING MODE SPECIAL)
-      copy:
-        src: /tmp/linklight/exercises/networking_v2/
-        dest: /home/{{ username }}/networking-workshop
-        remote_src: yes
-      when: special is defined
-
-    - name: Create demos folder with demos
-      copy:
-        src: /tmp/linklight/demos/
-        dest: /home/{{ username }}/demos
-        remote_src: yes
+# This is waiting on https://github.com/ansible/ansible/pull/41222
+# which will become available on ansible 2.8
+# - name: Move networking workshop folder to correct location  (NETWORKING MODE SPECIAL)
+#   copy:
+#     src: /tmp/linklight/exercises/networking_v2/
+#     dest: /home/{{ username }}/networking-workshop
+#     remote_src: yes
+#   when: networking
+- name: Move networking workshop folder to correct location  (NETWORKING MODE SPECIAL)
+  command: cp -r /tmp/linklight/exercises/networking_v2/ /home/{{ username }}/networking-workshop/
   when: networking
 
+# This is waiting on https://github.com/ansible/ansible/pull/41222
+# which will become available on ansible 2.8
+# - name: Create demos folder with demos
+#   copy:
+#     src: /tmp/linklight/demos/
+#     dest: /home/{{ username }}/demos
+#     remote_src: yes
+#   when: networking
+
+- name: Create demos folder with demos
+  command: cp -r /tmp/linklight/demos/ /home/{{ username }}/demos
+  when: networking
+
+# This is waiting on https://github.com/ansible/ansible/pull/41222
+# which will become available on ansible 2.8
+# - name: Move networking workshop folder to correct location  (F5 MODE)
+#   copy:
+#     src: /{{playbook_dir}}/linklight/exercises/ansible_f5/
+#     dest: /home/{{ username }}/networking-workshop
+#   when: f5workshop
+
 - name: Move networking workshop folder to correct location  (F5 MODE)
-  copy:
-    src: /tmp/linklight/exercises/ansible_f5/
-    dest: /home/{{ username }}/networking-workshop
-    remote_src: yes
+  shell: mkdir /home/{{ username }}/networking-workshop; cp -r /tmp/linklight/exercises/ansible_f5/* /home/{{ username }}/networking-workshop
   when: f5workshop
 
 - name: fix permissions of networking-workshop  (NETWORKING MODE)


### PR DESCRIPTION
##### SUMMARY
feedback has concluded that we need to support ansible 2.7 which is stable versus 2.8 which is still development until mayish. this will revert some changes that were made.

I have left the new changes commented out with the link to the issue and the reason why we are not doing yet.  I explored another option using the control node to perform the git action locally (through `delegate_to` parameter) and then using copy module from local control node to the managed nodes, but this increased provision time by 5 minutes and 30 seconds which is unacceptable performance degradation.

I have also begun making the networking_v2 the default and deprecating the networking v1 mode which has been labeled deprecated for some time.  

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
control_node role

##### ADDITIONAL INFORMATION

please test like this->
```
git clone https://github.com/network-automation
git checkout feb19
ansible-playook provision_lab.yml -e @extra_vars.yml
```
verify this doesn't break anything