### PR TITLE
deck overhaul

### DIFF
--- a/decks/README.md
+++ b/decks/README.md
@@ -1,9 +1,9 @@
 # Presentation Decks README
-
+Links to slides are here!
 
 ## Google Slides
 
-The Network and F5 Automation decks are managed internally at Red Hat Ansible with Google Slides.  They used to be managed in Github as code via [Revea](https://revealjs.com/#/).
+The Network and F5 Automation decks are managed internally at Red Hat Ansible with Google Slides.  They used to be managed in Github as code via [Reveal](https://revealjs.com/#/).
 
 - [Ansible Network Automation](https://docs.google.com/presentation/d/1qBq-9-f5a-XOwZ6gumWu27bj0qU5mhxtF5v1zyZ_hsM/edit?usp=sharing)
 - [Ansible F5 Automation](https://docs.google.com/presentation/d/1eSZHx_tVZ59U-nAYysehEXsSAJgLBr9SrgpjOfLUg84/edit?usp=sharing)
@@ -11,7 +11,7 @@ The Network and F5 Automation decks are managed internally at Red Hat Ansible wi
 
 **Why change to Google Slides?**
 
-More than 30% of the slides were graphics, flow charts, icons, diagrams, etc which were uploaded as SVG files.  This became way too much work to manage, and slides quickly fell out of date and required someone skilled in using Adobe or other graphics programs to edit the SVG file.  By using the internal Red Hat IT tools (which use Google Apps) this makes it very easy for the field engineers and Solution Architects, as well as the Ansible team to manage slides.  We do realize this will make it harder for community members but we were getting very little PRs, issues, etc on the slides.
+More than 30% of the slides were graphics, flow charts, icons, diagrams, etc which were uploaded as SVG files.  This became way too much of a barrier to manage individual SVG files, and slides quickly fell out of date and required someone skilled in using Adobe or other graphics programs to edit the SVG file.  By using the internal Red Hat IT tools (which use Google Apps) this makes it very easy for the field engineers and Solution Architects, as well as the Red Hat Ansible team to manage slides.  We do realize this can potentially make it harder for community members but we were getting very little PRs, issues, etc on the slides.
 
 **Can I still contribute?**
 


### PR DESCRIPTION
##### SUMMARY
this commit is to help with several things

- solve issue https://github.com/network-automation/linklight/issues/174
- update theme to match better to the mandated internal red hat ansible technical deck theme
- remove some extra text
- link to master deck when possible, color schemea for ansible overview was slightly off

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
decks/ansible_network.pdf

##### ADDITIONAL INFORMATION
N/A, no affect to exercises or provisioner 
