### PR TITLE
refactor to use workshop_type instead of workshop booleans

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -31,7 +31,7 @@ ec2_name_prefix: TESTWORKSHOP          # name prefix for all the VMs
 student_total: 2                       # creates student_total of workbenches for the workshop
 #OPTIONAL VARIABLES
 admin_password: ansible                # password for Ansible control node, defaults to ansible
-networking: true                       # Set this if you want the workshop in networking mode
+workshop_type: networking              # Set this if you want the workshop in networking mode
 create_login_page: true                # creates AWS S3 website for ec2_name_prefix.workshop_dns_zone
 workshop_dns_zone: rhdemo.io           # Sets the Route53 DNS zone to use for the S3 website
 towerinstall: true                     # automatically installs Tower to control node

--- a/provisioner/group_vars/all.yml
+++ b/provisioner/group_vars/all.yml
@@ -1,5 +1,4 @@
-networking: false
-f5workshop: false
+workshop_type: ""
 admin_password: ansible
 workshop_dns_zone: "rhdemo.io"
 s3_state: "present"
@@ -7,3 +6,7 @@ teardown: false
 towerinstall: false
 website_information: ""
 dns_information: "No errors with DNS"
+valid_workshop_types:
+  - networking
+  - f5
+  - engine

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -2,7 +2,7 @@
   hosts: localhost
   connection: local
   become: no
-  gather_facts: no
+  gather_facts: yes
   tasks:
     - name: make sure we are running correct Ansible Version
       assert:
@@ -10,21 +10,12 @@
           - ansible_version.major >= 2
           - ansible_version.minor >= 7
 
-      # F5workshop and networking workshop are two different workshops
-    - name: make sure f5workshop is not turned on when networking is
+    - name: make sure workshop_type is set to a correct value
       assert:
-        msg: "f5workshop and networking are mutually exclusive. Choose only one."
         that:
-          - not f5workshop
-      when: networking
-
-      # F5workshop and networking workshop are two different workshops
-    - name: make sure networking is not turned on when f5workshop is
-      assert:
-        msg: "networking and f5workshop are mutually exclusive. Choose only one."
-        that:
-          - not networking
-      when: f5workshop
+          - workshop_type is defined
+          - workshop_type is in valid_workshop_types
+        msg: "workshop_type must be defined and be one of: {{valid_workshop_types}}"
 
     - name: run role to check if local environment setup will work with AWS
       include_role:
@@ -85,7 +76,7 @@
   become: yes
   gather_facts: no
   roles:
-    - { role: webservers, when: f5workshop }
+    - { role: webservers, when: workshop_type == "f5" }
 
 - name: CONFIGURE CONTROL NODE
   hosts: control_nodes
@@ -114,7 +105,7 @@
   become: no
   gather_facts: no
   roles:
-    - { role: network_hostroutes, when: networking }
+    - { role: network_hostroutes, when: workshop_type == "networking" }
 
 - name: setup f5 nodes
   hosts: f5
@@ -122,7 +113,7 @@
   connection: local
   gather_facts: no
   roles:
-    - { role: f5_setup, when: f5workshop }
+    - { role: f5_setup, when: workshop_type == "f5" }
 
 - name: GATHER AWS FACTS FOR ROUTERS
   hosts: access,core

--- a/provisioner/roles/aws_check_setup/tasks/main.yml
+++ b/provisioner/roles/aws_check_setup/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: grab boto version
-  command: python -c 'import boto3; print(boto3.__version__)'
+  command: "{{ansible_python['executable']}} -c 'import boto3; print(boto3.__version__)'"
   register: py_cmd
 
 - name: make sure we are running correct boto version

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -231,7 +231,7 @@ $("document").ready(function(){
     <div class="container">
         <div class="row">
             <div class="col-sm-8">
-                {% if networking or f5workshop %}
+                {% if workshop_type in ['networking', 'f5'] %}
                 <h2>Network Automation Workshops</h2>
                 <p>These workshops are focused on networking platforms like Arista, Cisco, Juniper and F5.</p>
                 {% else %}
@@ -240,7 +240,7 @@ $("document").ready(function(){
                 {% endif %}
             </div>
         </div>
-        {% if networking %}
+        {% if workshop_type == "networking" %}
         <div class="row">
           <div class="col-sm-4">
               <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/networking_v2/">Ansible Network Exercises</a>
@@ -251,7 +251,7 @@ $("document").ready(function(){
           </div>
 
         </div>
-        {% elif f5workshop %}
+        {% elif workshop_type == "f5" %}
         <div class="row">
           <div class="col-sm-4">
               <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/ansible_f5/">Ansible F5 Exercises</a>

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -25,7 +25,7 @@
     name:
       - python-netaddr
     state: latest
-  when: not f5workshop
+  when: workshop_type != 'f5'
 
 - name: install ncclient for juniper devices (NETWORK AUTOMATION MODE)
   become: yes
@@ -33,9 +33,9 @@
     name:
       - ncclient
     state: latest
-  when: networking
+  when: workshop_type == 'networking'
 
-- name: block for f5workshop
+- name: block for f5 workshop
   block:
     - name: install f5 workshop dependicies
       become: yes
@@ -54,7 +54,7 @@
           - bigsuds
           - netaddr
         state: latest
-  when: f5workshop
+  when: workshop_type == "f5"
 
 - name: Install ansible.cfg and vimrc in home directory
   template:
@@ -70,19 +70,13 @@
     owner: "{{ username }}"
     group: "{{ username }}"
 
-- name: networking mode - setup control node
+- name: setup control node networking
   include_tasks: "networking.yml"
-  when: networking
-
-- name: f5 mode - setup control node
-  include_tasks: "networking.yml"
-  when: f5workshop
+  when: workshop_type in ['networking', 'f5']
 
 - name: engine (essentials) mode - setup control node
   include_tasks: "engine.yml"
-  when:
-    - not networking
-    - not f5workshop
+  when: workshop_type == 'engine'
 
 - name: check to see if ansible tower is already up and running
   uri:

--- a/provisioner/roles/control_node/tasks/networking.yml
+++ b/provisioner/roles/control_node/tasks/networking.yml
@@ -1,3 +1,10 @@
+# FIXME: This should probably be refactored to use things like the following
+# instead of hard coding
+#
+#   command: cp -r /tmp/linklight/exercises/{{workshop_type}}_v2/ /home/{{ username }}/{{workshop_type}}-workshop/
+#
+# That would enable a more generic role/scaffolding
+
 - name: Clone linklight repo (NETWORKING MODE)
   git:
     accept_hostkey: yes
@@ -13,10 +20,11 @@
 #     src: /tmp/linklight/exercises/networking_v2/
 #     dest: /home/{{ username }}/networking-workshop
 #     remote_src: yes
-#   when: networking
+#   when: workshop_type == 'networking'
+
 - name: Move networking workshop folder to correct location  (NETWORKING MODE SPECIAL)
   command: cp -r /tmp/linklight/exercises/networking_v2/ /home/{{ username }}/networking-workshop/
-  when: networking
+  when: workshop_type == 'networking'
 
 # This is waiting on https://github.com/ansible/ansible/pull/41222
 # which will become available on ansible 2.8
@@ -25,11 +33,11 @@
 #     src: /tmp/linklight/demos/
 #     dest: /home/{{ username }}/demos
 #     remote_src: yes
-#   when: networking
+#   when: workshop_type == 'networking'
 
 - name: Create demos folder with demos
   command: cp -r /tmp/linklight/demos/ /home/{{ username }}/demos
-  when: networking
+  when: workshop_type == 'networking'
 
 # This is waiting on https://github.com/ansible/ansible/pull/41222
 # which will become available on ansible 2.8
@@ -37,11 +45,11 @@
 #   copy:
 #     src: /{{playbook_dir}}/linklight/exercises/ansible_f5/
 #     dest: /home/{{ username }}/networking-workshop
-#   when: f5workshop
+#   when: workshop_type == 'f5'
 
 - name: Move networking workshop folder to correct location  (F5 MODE)
   shell: mkdir /home/{{ username }}/networking-workshop; cp -r /tmp/linklight/exercises/ansible_f5/* /home/{{ username }}/networking-workshop
-  when: f5workshop
+  when: workshop_type == 'f5'
 
 - name: fix permissions of networking-workshop  (NETWORKING MODE)
   file:

--- a/provisioner/roles/control_node/templates/ansible.cfg.j2
+++ b/provisioner/roles/control_node/templates/ansible.cfg.j2
@@ -5,12 +5,12 @@ timeout = 60
 deprecation_warnings = False
 host_key_checking = False
 retry_files_enabled = False
-{% if networking %}
+{% if workshop_type == 'networking' %}
 inventory = /home/{{username}}/networking-workshop/lab_inventory/hosts
 [persistent_connection]
 connect_timeout = 60
 command_timeout = 60
-{% elif f5workshop %}
+{% elif workshop_type == 'f5' %}
 inventory = /home/{{username}}/networking-workshop/lab_inventory/hosts
 {% else %}
 inventory = /home/{{username}}/lightbulb/lessons/lab_inventory/{{username}}-instances.txt

--- a/provisioner/roles/manage_ec2_instances/defaults/main.yml
+++ b/provisioner/roles/manage_ec2_instances/defaults/main.yml
@@ -6,7 +6,6 @@ ec2_wait: yes
 ec2_az: "{{ec2_region}}a"
 ec2_subnet: "172.16.0.0/16"
 ec2_subnet2: "172.17.0.0/16"
-networking: false
 ssh_port: 22
 
 ec2_control_node:

--- a/provisioner/roles/manage_ec2_instances/tasks/create_inventory.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/create_inventory.yml
@@ -28,16 +28,12 @@
 
 - name: engine (essentials) mode - setup inventory
   include_tasks: "addhost_engine.yml"
-  when:
-    - not networking
-    - not f5workshop
+  when: workshop_type == 'engine'
 
 - name: networking mode - setup inventory
   include_tasks: "addhost_networking.yml"
-  when:
-    - networking
-    - not f5workshop
+  when: workshop_type == 'networking'
 
 - name: f5 mode - setup inventory
   include_tasks: "addhost_f5.yml"
-  when: f5workshop
+  when: workshop_type == 'f5'

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_security_automation.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_security_automation.yml
@@ -3,6 +3,7 @@
     node1_node: "{{ ec2_lab_node_types['node1'] }}"
     node2_node: "{{ ec2_lab_node_types['node2'] }}"
     node3_node: "{{ ec2_lab_node_types['node3'] }}"
+  when: not networking
 
 - name: find ami for node1
   ec2_ami_facts:

--- a/provisioner/roles/manage_ec2_instances/tasks/provision.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/provision.yml
@@ -10,8 +10,8 @@
 
 ## This duplicates the above when networking workshop uses 2 VPCs
 - name: provision networking aws resources
-  include_tasks: resources_networking.yml
-  when: networking
+  include_tasks: resources_{{workshop_type}}.yml
+  when: workshop_type == 'networking'
 
 ## control node setup ###
 - name: set control node type
@@ -73,20 +73,6 @@
   when: control_output.instance_ids is not none
 
 ## Instance creation
-- name: provision ansible engine (essentials) instances
-  include_tasks: instances_engine.yml
-  when:
-    - not networking
-    - not f5workshop
+- name: provision workshop instances
+  include_tasks: 'instances_{{workshop_type}}.yml'
 
-- name: provision ansible networking workshop instances
-  include_tasks: instances_networking.yml
-  when:
-    - networking
-    - not f5workshop
-
-- name: provision ansible f5 workshop instances
-  include_tasks: instances_f5.yml
-  when:
-    - f5workshop
-    - not networking

--- a/provisioner/roles/tower_request/tasks/main.yml
+++ b/provisioner/roles/tower_request/tasks/main.yml
@@ -1,22 +1,4 @@
 ---
-- set_fact:
-    workshop_type: "networking"
-  when:
-    - networking is defined
-    - networking
-
-- set_fact:
-    workshop_type: "F5"
-  when:
-    - f5workshop is defined
-    - f5workshop
-
-- set_fact:
-    workshop_type: "Linux"
-  when:
-    - workshop_type is not match("F5")
-    - workshop_type is not match("networking")
-
 - name: execute a command with tower
   uri:
     url: https://ansible.rhdemo.io/api/v2/job_templates/22/launch/

--- a/provisioner/sample_workshops/sample-special.yml
+++ b/provisioner/sample_workshops/sample-special.yml
@@ -4,5 +4,5 @@ admin_password: ansible
 student_total: 2
 ## Optional Variables
 create_login_page: true
-networking: true
+workshop_type: networking
 special: all_cisco                     # possible values all_cisco or multievendor

--- a/provisioner/sample_workshops/sample-vars-auto.yml
+++ b/provisioner/sample_workshops/sample-vars-auto.yml
@@ -4,6 +4,6 @@ student_total: 2                      # amount of work benches to provision
 ## Optional Variables
 admin_password: ansible               # password used for student account on control node
 create_login_page: true               # creates HTML website for workshop
-networking: true                      # workshop is put into networking mode, uses two Cisco IOS-XE devices
+workshop_type: "networking"           # workshop is put into networking mode, uses two Cisco IOS-XE devices
 autolicense: true                     # when towerinstall is on, this will license it with provided license
 towerinstall: true                    # this will install Ansible Tower on all control nodes

--- a/provisioner/sample_workshops/sample-vars-f5.yml
+++ b/provisioner/sample_workshops/sample-vars-f5.yml
@@ -5,5 +5,5 @@ student_total: 2                      # amount of work benches to provision
 ## Optional Variables
 admin_password: ansible               # password used for student account on control node
 create_login_page: true               # creates HTML website for workshop
-f5workshop: true                      # workshp runs in F5 mode
+workshop_type: f5                     # workshp runs in F5 mode
 xrdp: true                            # install xrdp with xfce for graphical interface

--- a/provisioner/sample_workshops/sample-vars-networking.yml
+++ b/provisioner/sample_workshops/sample-vars-networking.yml
@@ -1,7 +1,7 @@
-ec2_region: us-east-1                 # region where the nodes will live
-ec2_name_prefix: TESTWORKSHOP         # name prefix for all the VMs
-student_total: 2											# amount of work benches to provision
+ec2_region: us-east-1               # region where the nodes will live
+ec2_name_prefix: TESTWORKSHOP       # name prefix for all the VMs
+student_total: 2                    # amount of work benches to provision
 ## Optional Variables
-admin_password: ansible								# password used for student account on control node
-create_login_page: true								# creates HTML website for workshop
-networking: true											# workshop is put into networking mode, uses two Cisco IOS-XE devices
+admin_password: ansible             # password used for student account on control node
+create_login_page: true             # creates HTML website for workshop
+workshop_type: networking           # workshop is put into networking mode, uses two Cisco IOS-XE devices

--- a/provisioner/sample_workshops/sample-vars.yml
+++ b/provisioner/sample_workshops/sample-vars.yml
@@ -1,6 +1,6 @@
 ec2_region: us-east-1                 # region where the nodes will live
 ec2_name_prefix: TESTWORKSHOP         # name prefix for all the VMs
-student_total: 2											# amount of work benches to provision
+student_total: 2                      # amount of work benches to provision
 ## Optional Variables
-admin_password: ansible								# password used for student account on control node
-create_login_page: true									# creates HTML website for workshop
+admin_password: ansible               # password used for student account on control node
+create_login_page: true               # creates HTML website for workshop


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
refactor to use `workshop_type` instead of workshop booleans to make it easier to extend to new use cases 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the role, task or feature below -->
provisioner/provision_lab.yml


