### PR TITLE
Fix broken links to ansible_network preso

### DIFF
--- a/exercises/networking_v2/README.ja.md
+++ b/exercises/networking_v2/README.ja.md
@@ -5,7 +5,7 @@
 ## Presentation
 プレゼンテーション用のスライドが必要ですか？
 こちらを確認ください。:
-[Ansible Networking Linklight Deck](../../decks/ansible-networking_v2.html)
+[Ansible Networking Linklight Deck](../../decks/ansible_network.pdf)
 
 ## Ansible Network Automation Exercises
 

--- a/exercises/networking_v2/README.md
+++ b/exercises/networking_v2/README.md
@@ -4,7 +4,7 @@ This content is a multi-purpose toolkit for effectively demonstrating Ansible's 
 
 ## Presentation
 Want the Presentation Deck?  Its right here:
-[Ansible Networking Linklight Deck](../../decks/ansible-networking_v2.html)
+[Ansible Networking Linklight Deck](../../decks/ansible_network.pdf)
 
 ## Ansible Network Automation Exercises
 


### PR DESCRIPTION
##### SUMMARY
The links to the ansible_network.pdf are broken in the starter page for the Ansible networking lab. This fixes them.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Networking exercise starter page

##### ADDITIONAL INFORMATION
Just a simple link fix...
