### PR TITLE
Syntax cleanup to avoid depreciations in 2.8

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -3,7 +3,9 @@
   connection: local
   become: no
   gather_facts: no
+
   tasks:
+
     - name: make sure we are running correct Ansible Version
       assert:
         that:
@@ -11,12 +13,13 @@
           - ansible_version.minor >= 7
 
       # F5workshop and networking workshop are two different workshops
+
     - name: make sure f5workshop is not turned on when networking is
       assert:
         msg: "f5workshop and networking are mutually exclusive. Choose only one."
         that:
           - not f5workshop
-      when: networking
+      when: networking | bool
 
       # F5workshop and networking workshop are two different workshops
     - name: make sure networking is not turned on when f5workshop is
@@ -24,7 +27,7 @@
         msg: "networking and f5workshop are mutually exclusive. Choose only one."
         that:
           - not networking
-      when: f5workshop
+      when: f5workshop | bool
 
     - name: run role to check if local environment setup will work with AWS
       include_role:
@@ -45,7 +48,7 @@
       block:
         - name: Check that the provided license exists
           stat:
-            path: "{{playbook_dir}}/tower_license.json"
+            path: "{{ playbook_dir }}/tower_license.json"
           register: stat_result
         - debug:
             var: stat_result
@@ -55,7 +58,7 @@
            - not stat_result.stat.exists
       when:
        - autolicense is defined
-       - autolicense
+       - autolicense | bool
 
 - name: Create lab instances in AWS
   hosts: localhost
@@ -195,14 +198,14 @@
         summary_information: |
           PROVISIONER SUMMARY
           *******************
-          - Workshop name is {{ec2_name_prefix}}
-          - Instructor inventory is located at  {{playbook_dir}}/{{ec2_name_prefix}}/instructor_inventory.txt
-          - Private key is located at {{playbook_dir}}/{{ec2_name_prefix}}/{{ec2_name_prefix}}.pem
-          {{website_information}}
+          - Workshop name is {{ ec2_name_prefix }}
+          - Instructor inventory is located at  {{ playbook_dir }}/{{ ec2_name_prefix }}/instructor_inventory.txt
+          - Private key is located at {{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}.pem
+          {{ website_information }}
           FAILURES
           *******************
-          {{dns_information}}
+          {{ dns_information }}
 
     - name: Print Summary Information
       debug:
-        msg: "{{summary_information}}"
+        msg: "{{ summary_information }}"

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -22,6 +22,7 @@
       when: networking | bool
 
       # F5workshop and networking workshop are two different workshops
+
     - name: make sure networking is not turned on when f5workshop is
       assert:
         msg: "networking and f5workshop are mutually exclusive. Choose only one."
@@ -53,7 +54,7 @@
         - debug:
             var: stat_result
         - fail:
-            msg: "autolicense is turned on, but we need a license located at {{playbook_dir}}/tower_license.json"
+            msg: "autolicense is turned on, but we need a license located at {{ playbook_dir }}/tower_license.json"
           when:
            - not stat_result.stat.exists
       when:
@@ -88,7 +89,7 @@
   become: yes
   gather_facts: no
   roles:
-    - { role: webservers, when: f5workshop }
+    - { role: webservers, when: f5workshop | bool }
 
 - name: CONFIGURE CONTROL NODE
   hosts: control_nodes
@@ -102,7 +103,7 @@
   become: yes
   gather_facts: no
   roles:
-    - { role: aws_dns, when: create_login_page is defined and create_login_page }
+    - { role: aws_dns, when: create_login_page is defined and create_login_page | bool }
 
 - name: Setup Amazon S3 Website for Student Login
   hosts: localhost
@@ -110,14 +111,14 @@
   become: no
   gather_facts: no
   roles:
-    - { role: aws_workshop_login_page, when: create_login_page is defined and create_login_page }
+    - { role: aws_workshop_login_page, when: create_login_page is defined and create_login_page | bool }
 
 - name: Setup Host routes for ansible control node and host1 when in networking mode
   hosts: "managed_nodes:control_nodes"
   become: no
   gather_facts: no
   roles:
-    - { role: network_hostroutes, when: networking }
+    - { role: network_hostroutes, when: networking | bool}
 
 - name: setup f5 nodes
   hosts: f5
@@ -125,7 +126,7 @@
   connection: local
   gather_facts: no
   roles:
-    - { role: f5_setup, when: f5workshop }
+    - { role: f5_setup, when: f5workshop | bool }
 
 - name: GATHER AWS FACTS FOR ROUTERS
   hosts: access,core

--- a/provisioner/roles/aws_check_setup/tasks/main.yml
+++ b/provisioner/roles/aws_check_setup/tasks/main.yml
@@ -14,19 +14,19 @@
     msg: "Amazon AWS does not allow underscores _ for s3 websites, please see https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html"
   when:
     - create_login_page is defined
-    - create_login_page
+    - create_login_page | bool
     - "'_' in ec2_name_prefix"
 
-- name: FIND AZ ZONE FOR REGION {{ec2_region}}
+- name: FIND AZ ZONE FOR REGION {{ ec2_region }}
   aws_az_facts:
-    region: "{{ec2_region}}"
+    region: "{{ ec2_region }}"
   register: az_names
 
 # - debug:
 #     var: az_names
 
 - name: SET AZ ZONE TO FIRST AVAILABLE
-  set_fact: ec2_az={{az_names.availability_zones[0].zone_name}}
+  set_fact: ec2_az={{ az_names.availability_zones[0].zone_name }}
 
 - name: grab information about AWS user
   aws_caller_facts:

--- a/provisioner/roles/aws_dns/tasks/create.yml
+++ b/provisioner/roles/aws_dns/tasks/create.yml
@@ -2,13 +2,13 @@
   become: False
   route53:
     state: "{{ s3_state }}"
-    zone: "{{workshop_dns_zone}}"
-    record: "{{username}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
+    zone: "{{ workshop_dns_zone }}"
+    record: "{{ username }}.{{ ec2_name_prefix | lower }}.{{ workshop_dns_zone }}"
     type: A
     overwrite: yes
-    value: "{{ansible_host}}"
+    value: "{{ ansible_host }}"
   delegate_to: localhost
 
 - name: CERTBOT FOR TOWER
   include_tasks: "tower.yml"
-  when: towerinstall
+  when: towerinstall | bool

--- a/provisioner/roles/aws_dns/tasks/main.yml
+++ b/provisioner/roles/aws_dns/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: REMOVE DNS ENTRIES FOR EACH TOWER NODE
   include_tasks: teardown.yml
-  when: teardown
+  when: teardown | bool
 
 - name: CHECK TO SEE IF SSL CERT ALREADY APPLIED
   uri:
@@ -13,10 +13,10 @@
   register: check_cert
   ignore_errors: yes
   when:
-    - not teardown
+    - not teardown | bool
 
 - name: CREATE DNS ENTRIES FOR EACH TOWER NODE AND SSL CERT
   include_tasks: create.yml
   when:
-    - not teardown
+    - not teardown | bool
     - check_cert is failed

--- a/provisioner/roles/aws_dns/tasks/teardown.yml
+++ b/provisioner/roles/aws_dns/tasks/teardown.yml
@@ -1,26 +1,26 @@
 - name: GRAB ZONE ID
   route53_zone:
-    zone: "{{workshop_dns_zone}}"
+    zone: "{{ workshop_dns_zone }}"
   register: AWSINFO
 
 - name: GRAB ROUTE53 INFORMATION
   route53_facts:
     type: A
     query: record_sets
-    hosted_zone_id: "{{AWSINFO.zone_id}}"
-    start_record_name: "student1.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
-    max_items: "{{student_total}}"
+    hosted_zone_id: "{{ AWSINFO.zone_id }}"
+    start_record_name: "student1.{{ ec2_name_prefix | lower}}.{{ workshop_dns_zone }}"
+    max_items: "{{ student_total }}"
   register: record_sets
 
 - name: DELETE DNS ENTRIES FOR EACH STUDENT
   become: False
   route53:
     state: "{{ s3_state }}"
-    zone: "{{workshop_dns_zone}}"
-    record: "student{{item}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
+    zone: "{{ workshop_dns_zone }}"
+    record: "student{{ item }}.{{ ec2_name_prefix | lower }}.{{ workshop_dns_zone }}"
     type: A
     value: "{{ (records | first | first)['Value'] }}"
   loop: "{{ range(1, student_total + 1)|list }}"
   vars:
-    records: '{{record_sets.ResourceRecordSets | selectattr("Name", "match", "student" + item|string + "." + ec2_name_prefix|lower + "." + workshop_dns_zone) | map(attribute="ResourceRecords") | list }}'
-  when: records
+    records: '{{ record_sets.ResourceRecordSets | selectattr("Name", "match", "student" + item|string + "." + ec2_name_prefix|lower + "." + workshop_dns_zone) | map(attribute="ResourceRecords") | list }}'
+  when: records | bool

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -43,7 +43,7 @@
     name:
       - ncclient
     state: latest
-  when: networking
+  when: networking | bool
 
 - name: block for f5workshop
   block:
@@ -64,7 +64,7 @@
           - bigsuds
           - netaddr
         state: latest
-  when: f5workshop
+  when: f5workshop | bool
 
 - name: Install ansible.cfg and vimrc in home directory
   template:
@@ -82,11 +82,11 @@
 
 - name: networking mode - setup control node
   include_tasks: "networking.yml"
-  when: networking
+  when: networking | bool
 
 - name: f5 mode - setup control node
   include_tasks: "networking.yml"
-  when: f5workshop
+  when: f5workshop | bool
 
 - name: engine (essentials) mode - setup control node
   include_tasks: "engine.yml"
@@ -106,13 +106,13 @@
   ignore_errors: yes
   when:
     - towerinstall is defined
-    - towerinstall
+    - towerinstall | bool
 
 - name: install tower if knob is set
   include_tasks: "tower.yml"
   when:
     - towerinstall is defined
-    - towerinstall
+    - towerinstall | bool
     - check_tower is failed
 
 - name: Ensure eula is accepted if posting license
@@ -126,7 +126,7 @@
   become: no
   when:
     - autolicense is defined
-    - autolicense
+    - autolicense | bool
 
 - name: Post license key
   uri:
@@ -140,8 +140,8 @@
     force_basic_auth: yes
   when:
     - autolicense is defined
-    - autolicense
+    - autolicense | bool
 
 - name: INSTALL VSCODE AND XRDP
   include_tasks: gui.yml
-  when: xrdp
+  when: xrdp | bool

--- a/provisioner/roles/control_node/tasks/networking.yml
+++ b/provisioner/roles/control_node/tasks/networking.yml
@@ -14,9 +14,10 @@
 #     dest: /home/{{ username }}/networking-workshop
 #     remote_src: yes
 #   when: networking
+#
 - name: Move networking workshop folder to correct location  (NETWORKING MODE SPECIAL)
   command: cp -r /tmp/linklight/exercises/networking_v2/ /home/{{ username }}/networking-workshop/
-  when: networking
+  when: networking | bool
 
 # This is waiting on https://github.com/ansible/ansible/pull/41222
 # which will become available on ansible 2.8
@@ -29,7 +30,7 @@
 
 - name: Create demos folder with demos
   command: cp -r /tmp/linklight/demos/ /home/{{ username }}/demos
-  when: networking
+  when: networking | bool
 
 # This is waiting on https://github.com/ansible/ansible/pull/41222
 # which will become available on ansible 2.8
@@ -41,7 +42,7 @@
 
 - name: Move networking workshop folder to correct location  (F5 MODE)
   shell: mkdir /home/{{ username }}/networking-workshop; cp -r /tmp/linklight/exercises/ansible_f5/* /home/{{ username }}/networking-workshop
-  when: f5workshop
+  when: f5workshop | bool
 
 - name: fix permissions of networking-workshop  (NETWORKING MODE)
   file:

--- a/provisioner/roles/manage_ec2_instances/tasks/create_inventory.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/create_inventory.yml
@@ -19,8 +19,8 @@
     ansible_host: "{{ item.public_ip_address }}"
     ansible_user: "{{ ec2_login_names[ansible_node] }}"
     ansible_port: "{{ ssh_port }}"
-    ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
-    private_ip: "{{item.private_ip_address}}"
+    ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}-private.pem"
+    private_ip: "{{ item.private_ip_address }}"
     groups:
       - managed_nodes
       - control_nodes
@@ -35,9 +35,9 @@
 - name: networking mode - setup inventory
   include_tasks: "addhost_networking.yml"
   when:
-    - networking
+    - networking | bool
     - not f5workshop
 
 - name: f5 mode - setup inventory
   include_tasks: "addhost_f5.yml"
-  when: f5workshop
+  when: f5workshop | bool

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_networking.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_networking.yml
@@ -83,7 +83,7 @@
       name: "{{ ec2_instance_types[rtr2_node].filter }}"
       architecture: "{{ ec2_instance_types[rtr2_node].architecture }}"
   register: amis
-  when: networking
+  when: networking | bool
 
 - name: save ami for rtr2 (NETWORKING MODE)
   set_fact:
@@ -174,7 +174,7 @@
         Linklight: "This was provisioned through the linklight provisioner"
         Students: "{{student_total}}"
         short_name: "rtr3"
-        ansible_network_os: "{{ec2_instance_types[rtr3_node].os}}"
+        ansible_network_os: "{{ ec2_instance_types[rtr3_node].os }}"
     with_indexed_items:
       - "{{ rtr3_output.instance_ids }}"
     when: rtr3_output.instance_ids is not none
@@ -189,7 +189,7 @@
         name: "{{ ec2_instance_types[rtr4_node].filter }}"
         architecture: "{{ ec2_instance_types[rtr4_node].architecture }}"
     register: amis
-    when: networking
+    when: networking | bool
 
   - name: save ami for rtr4 (NETWORKING MODE)
     set_fact:
@@ -206,7 +206,7 @@
       region: "{{ ec2_region }}"
       exact_count: "{{ student_total }}"
       count_tag:
-        Workshop_rtr4: "{{ec2_name_prefix}}-rtr4"
+        Workshop_rtr4: "{{ ec2_name_prefix }}-rtr4"
       wait: "{{ ec2_wait }}"
       vpc_subnet_id: "{{ ec2_vpc_subnet_id2 }}"
     register: rtr4_output
@@ -214,20 +214,20 @@
   - name: Ensure tags are present for rtr4 node (NETWORKING MODE)
     ec2_tag:
       region: "{{ ec2_region }}"
-      resource: "{{item.1}}"
+      resource: "{{ item.1 }}"
       state: present
       tags:
-        Name: "{{ ec2_name_prefix }}-student{{item.0 + 1}}-rtr4"
-        Workshop_rtr4: "{{ec2_name_prefix}}-rtr4"
-        Workshop: "{{ec2_name_prefix}}"
+        Name: "{{ ec2_name_prefix }}-student{{ item.0 + 1 }}-rtr4"
+        Workshop_rtr4: "{{ ec2_name_prefix }}-rtr4"
+        Workshop: "{{ ec2_name_prefix }}"
         Index: "{{ item[0] }}"
-        Student: "student{{item.0 + 1}}"
+        Student: "student{{ item.0 + 1 }}"
         AWS_USERNAME: "{{ linklight_user }}"
         Info: "AWS_USERNAME that provisioned this-> {{ linklight_user }}"
         Linklight: "This was provisioned through the linklight provisioner"
-        Students: "{{student_total}}"
+        Students: "{{ student_total }}"
         short_name: "rtr4"
-        ansible_network_os: "{{ec2_instance_types[rtr4_node].os}}"
+        ansible_network_os: "{{ ec2_instance_types[rtr4_node].os }}"
     with_indexed_items:
       - "{{ rtr4_output.instance_ids }}"
     when: rtr4_output.instance_ids is not none
@@ -257,7 +257,7 @@
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
     count_tag:
-      Workshop_host1: "{{ec2_name_prefix}}-host1"
+      Workshop_host1: "{{ ec2_name_prefix }}-host1"
     wait: "{{ ec2_wait }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id2 }}"
   register: host1_output
@@ -265,18 +265,18 @@
 - name: Ensure tags are present for host1 node (NETWORKING MODE)
   ec2_tag:
     region: "{{ ec2_region }}"
-    resource: "{{item.1}}"
+    resource: "{{ item.1 }}"
     state: present
     tags:
-      Name: "{{ ec2_name_prefix }}-student{{item.0 + 1}}-host1"
-      Workshop_host1: "{{ec2_name_prefix}}-host1"
-      Workshop: "{{ec2_name_prefix}}"
+      Name: "{{ ec2_name_prefix }}-student{{ item.0 + 1 }}-host1"
+      Workshop_host1: "{{ ec2_name_prefix }}-host1"
+      Workshop: "{{ ec2_name_prefix }}"
       Index: "{{ item[0] }}"
-      Student: "student{{item.0 + 1}}"
+      Student: "student{{ item.0 + 1 }}"
       AWS_USERNAME: "{{ linklight_user }}"
       Info: "AWS_USERNAME that provisioned this-> {{ linklight_user }}"
       Linklight: "This was provisioned through the linklight provisioner"
-      Students: "{{student_total}}"
+      Students: "{{ student_total }}"
       short_name: "host1"
   with_indexed_items:
     - "{{ host1_output.instance_ids }}"
@@ -286,21 +286,21 @@
   ec2_eni_facts:
     region: "{{ ec2_region }}"
     filters:
-      vpc-id: "{{ec2_vpc_id}}"
+      vpc-id: "{{ ec2_vpc_id }}"
   register: eni_facts_1
 
 - name: grab all network interfaces for VPC 2 (NETWORKING MODE)
   ec2_eni_facts:
     region: "{{ ec2_region }}"
     filters:
-      vpc-id: "{{ec2_vpc_id2}}"
+      vpc-id: "{{ ec2_vpc_id2 }}"
   register: eni_facts_2
 
-- name: Disable Source/Dest check on instance {{ec2_vpc_id1}} (NETWORKING MODE)
+- name: Disable Source/Dest check on instance {{ ec2_vpc_id1 }} (NETWORKING MODE)
   ec2_eni:
     eni_id: "{{ item['network_interface_id'] }}"
     region: "{{ ec2_region }}"
     source_dest_check: false
   with_items:
-    - "{{eni_facts_1['network_interfaces']}}"
-    - "{{eni_facts_2['network_interfaces']}}"
+    - "{{ eni_facts_1['network_interfaces'] }}"
+    - "{{ eni_facts_2['network_interfaces'] }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/main.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: teardown.yml
-  when: teardown
+  when: teardown | bool
 
 - name: provision workshop in AWS public cloud
   block:
@@ -8,4 +8,4 @@
 
     - name: create instructor_inventory, and student files
       include_tasks: create_inventory.yml
-  when: not teardown
+  when: not teardown | bool

--- a/provisioner/roles/manage_ec2_instances/tasks/provision.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/provision.yml
@@ -11,7 +11,7 @@
 ## This duplicates the above when networking workshop uses 2 VPCs
 - name: provision networking aws resources
   include_tasks: resources_networking.yml
-  when: networking
+  when: networking | bool
 
 ## control node setup ###
 - name: set control node type
@@ -55,14 +55,14 @@
 - name: Ensure tags are present
   ec2_tag:
     region: "{{ ec2_region }}"
-    resource: "{{item.1}}"
+    resource: "{{ item.1 }}"
     state: present
     tags:
-      Name: "{{ ec2_name_prefix }}-student{{item.0 + 1}}-ansible"
-      Workshop_ansible: "{{ec2_name_prefix}}-ansible"
-      Workshop: "{{ec2_name_prefix}}"
+      Name: "{{ ec2_name_prefix }}-student{{ item.0 + 1 }}-ansible"
+      Workshop_ansible: "{{ ec2_name_prefix }}-ansible"
+      Workshop: "{{ ec2_name_prefix }}"
       Index: "{{ item[0] }}"
-      Student: "student{{item.0 + 1}}"
+      Student: "student{{ item.0 + 1 }}"
       Username: "{{ linklight_user }}"
       Info: "Username that provisioned this-> {{ linklight_user }}"
       Linklight: "This was provisioned through the linklight provisioner"
@@ -82,11 +82,11 @@
 - name: provision ansible networking workshop instances
   include_tasks: instances_networking.yml
   when:
-    - networking
+    - networking | bool
     - not f5workshop
 
 - name: provision ansible f5 workshop instances
   include_tasks: instances_f5.yml
   when:
-    - f5workshop
+    - f5workshop | bool
     - not networking

--- a/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
@@ -3,7 +3,7 @@
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
-      "tag:Workshop": "{{ec2_name_prefix}}"
+      "tag:Workshop": "{{ ec2_name_prefix }}"
   register: all_workshop_nodes
 
 # - name: debug test
@@ -31,7 +31,7 @@
       "tag:Name": "{{ ec2_name_prefix }}-vpc2"
     region: "{{ ec2_region }}"
   register: vpc_net_facts2
-  when: networking
+  when: networking | bool
 
 # - name: debugging vpc id for {{ ec2_name_prefix }}
 #   debug:
@@ -46,112 +46,112 @@
 
 - name: set variables for instance creation dynamically since VPC was not supplied by user (NETWORKING MODE)
   set_fact:
-    ec2_vpc_id2: "{{vpc_net_facts2.vpcs[0].id}}"
+    ec2_vpc_id2: "{{ vpc_net_facts2.vpcs[0].id }}"
     ec2_security_group2: "{{ ec2_name_prefix }}-insecure_all2"
   when:
-    - networking
-    - vpc_net_facts2.vpcs|length > 0
+    - networking | bool
+    - vpc_net_facts2.vpcs | length > 0
     - ec2_security_group2 is undefined
 
 - name: Deleted EC2 security group for VPC vpc-{{ ec2_name_prefix }}
   ec2_group:
-    name: "{{ec2_security_group}}"
+    name: "{{ ec2_security_group }}"
     region: "{{ ec2_region }}"
-    vpc_id: "{{ec2_vpc_id}}"
+    vpc_id: "{{ ec2_vpc_id }}"
     state: absent
   register: delete_sg
   until: delete_sg is not failed
   retries: 50
-  when: vpc_net_facts.vpcs|length > 0
+  when: vpc_net_facts.vpcs | length > 0
 
 - name: Deleted EC2 security group for VPC-2 vpc-{{ ec2_name_prefix }} (NETWORKING MODE)
   ec2_group:
-    name: "{{ec2_security_group2}}"
+    name: "{{ ec2_security_group2 }}"
     region: "{{ ec2_region }}"
-    vpc_id: "{{ec2_vpc_id2}}"
+    vpc_id: "{{ ec2_vpc_id2 }}"
     state: absent
   register: delete_sgnetworking
   until: delete_sgnetworking is not failed
   retries: 50
   when:
-    - networking
-    - vpc_net_facts2.vpcs|length > 0
+    - networking | bool
+    - vpc_net_facts2.vpcs | length > 0
 
 - name: Delete subnet for {{ ec2_name_prefix }}-vpc
   ec2_vpc_subnet:
     region: "{{ ec2_region }}"
-    az: "{{ec2_az}}"
-    vpc_id: "{{ec2_vpc_id}}"
-    cidr: "{{ec2_subnet}}"
+    az: "{{ ec2_az }}"
+    vpc_id: "{{ ec2_vpc_id }}"
+    cidr: "{{ ec2_subnet }}"
     state: absent
-  when: vpc_net_facts.vpcs|length > 0
+  when: vpc_net_facts.vpcs | length > 0
 
 - name: Delete subnet for {{ ec2_name_prefix }}-vpc2 (NETWORKING MODE)
   ec2_vpc_subnet:
     region: "{{ ec2_region }}"
-    az: "{{ec2_az}}"
-    vpc_id: "{{ec2_vpc_id2}}"
-    cidr: "{{ec2_subnet2}}"
+    az: "{{ ec2_az }}"
+    vpc_id: "{{ ec2_vpc_id2 }}"
+    cidr: "{{ ec2_subnet2 }}"
     state: absent
   when:
-    - networking
-    - vpc_net_facts2.vpcs|length > 0
+    - networking | bool
+    - vpc_net_facts2.vpcs | length > 0
 
 - name: vpc internet gateway is deleted for vpc-{{ ec2_name_prefix }}
   ec2_vpc_igw:
     region: "{{ ec2_region }}"
-    vpc_id: "{{ec2_vpc_id}}"
+    vpc_id: "{{ ec2_vpc_id }}"
     state: absent
   when: vpc_net_facts.vpcs|length > 0
 
 - name: vpc internet gateway is deleted for vpc-{{ ec2_name_prefix }} (NETWORKING MODE)
   ec2_vpc_igw:
     region: "{{ ec2_region }}"
-    vpc_id: "{{ec2_vpc_id2}}"
+    vpc_id: "{{ ec2_vpc_id2 }}"
     state: absent
   when:
-    - networking
-    - vpc_net_facts2.vpcs|length > 0
+    - networking | bool
+    - vpc_net_facts2.vpcs | length > 0
 
 - name: grab route information for {{ ec2_name_prefix }} on {{ ec2_region }}
   ec2_vpc_route_table_facts:
     region: "{{ ec2_region }}"
     filters:
-      vpc_id: "{{ec2_vpc_id}}"
+      vpc_id: "{{ ec2_vpc_id }}"
   register: route_table_facts
-  when: vpc_net_facts.vpcs|length > 0
+  when: vpc_net_facts.vpcs | length > 0
 
 - name: grab route information for {{ ec2_name_prefix }} on {{ ec2_region }} vpc2 (NETWORKING MODE)
   ec2_vpc_route_table_facts:
     region: "{{ ec2_region }}"
     filters:
-      vpc_id: "{{ec2_vpc_id2}}"
+      vpc_id: "{{ ec2_vpc_id2 }}"
   register: route_table_facts2
   when:
-    - networking
-    - vpc_net_facts2.vpcs|length > 0
+    - networking | bool
+    - vpc_net_facts2.vpcs | length > 0
 
 - name: vpc public subnet route table is deleted
   ec2_vpc_route_table:
     region: "{{ ec2_region }}"
-    vpc_id: "{{ec2_vpc_id}}"
-    route_table_id: "{{item.id}}"
+    vpc_id: "{{ ec2_vpc_id }}"
+    route_table_id: "{{ item.id }}"
     lookup: id
     state: absent
-  with_items: "{{route_table_facts.route_tables}}"
-  when: vpc_net_facts.vpcs|length > 0 and item.associations == []
+  with_items: "{{ route_table_facts.route_tables }}"
+  when: vpc_net_facts.vpcs | length > 0 and item.associations == []
 
 - name: vpc public subnet route table is deleted (VPC2) (NETWORKING MODE)
   ec2_vpc_route_table:
     region: "{{ ec2_region }}"
-    vpc_id: "{{ec2_vpc_id2}}"
-    route_table_id: "{{item.id}}"
+    vpc_id: "{{ ec2_vpc_id2 }}"
+    route_table_id: "{{ item.id }}"
     lookup: id
     state: absent
-  with_items: "{{route_table_facts2.route_tables}}"
+  with_items: "{{ route_table_facts2.route_tables }}"
   when:
-    - networking
-    - vpc_net_facts2.vpcs|length > 0
+    - networking | bool
+    - vpc_net_facts2.vpcs | length > 0
     - item.associations == []
 
 - name: set keys for instance creation dynamically since key was not supplied by user
@@ -160,7 +160,7 @@
 
 - name: delete ssh key pair for workshop {{ ec2_name_prefix }}
   ec2_key:
-    name: "{{ec2_key_name}}"
+    name: "{{ ec2_key_name }}"
     region: "{{ ec2_region }}"
     state: absent
 
@@ -178,4 +178,4 @@
     region: "{{ ec2_region }}"
     state: absent
   when:
-    - networking
+    - networking | bool

--- a/provisioner/roles/network_hostroutes/tasks/main.yml
+++ b/provisioner/roles/network_hostroutes/tasks/main.yml
@@ -3,7 +3,7 @@
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
-      "tag:Name": "{{ec2_name_prefix}}-{{username}}-rtr1"
+      "tag:Name": "{{ ec2_name_prefix }}-{{ username }}-rtr1"
   register: rtr1_facts
   delegate_to: localhost
 
@@ -12,14 +12,14 @@
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
-      "tag:Name": "{{ec2_name_prefix}}-{{username}}-rtr2"
+      "tag:Name": "{{ ec2_name_prefix }}-{{ username }}-rtr2"
   register: rtr2_facts
   delegate_to: localhost
 
 - name: add route to 172.17.0.0/16 subnet on ansible node
   lineinfile:
     path: /etc/sysconfig/network-scripts/route-eth0
-    line: "172.17.0.0/16 via {{rtr1_facts.instances[0].private_ip_address}}"
+    line: "172.17.0.0/16 via {{ rtr1_facts.instances[0].private_ip_address }}"
     create: yes
   notify: restart network
   become: yes
@@ -28,7 +28,7 @@
 - name: add route to 172.16.0.0/16 subnet on host1 node
   lineinfile:
     path: /etc/sysconfig/network-scripts/route-eth0
-    line: "172.16.0.0/16 via {{rtr2_facts.instances[0].private_ip_address}}"
+    line: "172.16.0.0/16 via {{ rtr2_facts.instances[0].private_ip_address }}"
     create: yes
   notify: restart network
   become: yes

--- a/provisioner/roles/tower_request/tasks/main.yml
+++ b/provisioner/roles/tower_request/tasks/main.yml
@@ -3,13 +3,13 @@
     workshop_type: "networking"
   when:
     - networking is defined
-    - networking
+    - networking | bool
 
 - set_fact:
     workshop_type: "F5"
   when:
     - f5workshop is defined
-    - f5workshop
+    - f5workshop | bool
 
 - set_fact:
     workshop_type: "Linux"


### PR DESCRIPTION
##### SUMMARY
Ansible 2.8, as forced by the devel branch, no longer likes bare variables  and highlights the depreciation e.g.

`when: towerinstall
`
Generates:

DEPRECATION WARNING]: evaluating towerinstall as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see
CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. 
In 2.12 onwards these must be written

`when: towerinstall | bool
`
Cleaned up each depreciation I saw whilst testing engine, cisco, and f5 workshops. Whilst at it any variables written `{{foo}}` were replaced with `{{ foo }}`

Tested via provisions and teardowns of engine, cisco, and f5 workshops
##### ISSUE TYPE

- Feature Pull Request - syntax cleanup


##### ADDITIONAL INFORMATION
 To reproduce the warnings run `ansible-playbook provsion_lab.yml` -e @foo with ansible 2.8.x

Tested with ansible 2.8.0rc1
