### PR TITLE
fixing mentions of redhatgov.io which is specific to public spector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ ansible/
 *.box
 *.retry
 demos/servicenow/private.yml
+*.html

--- a/exercises/ansible_rhel/3-variables/README.md
+++ b/exercises/ansible_rhel/3-variables/README.md
@@ -103,8 +103,8 @@ Create a `templates` directory in your project directory and download two files.
 ```bash
 mkdir templates
 cd templates
-curl -O http://ansible-workshop.redhatgov.io/workshop-files/httpd.conf.j2
-curl -O http://ansible-workshop.redhatgov.io/workshop-files/index.html.j2
+curl -O http://ansible-workshop.rhdemo.io/workshop-files/httpd.conf.j2
+curl -O http://ansible-workshop.rhdemo.io/workshop-files/index.html.j2
 ```
 
 ### Step 2:

--- a/exercises/ansible_rhel/5-role/README.md
+++ b/exercises/ansible_rhel/5-role/README.md
@@ -189,8 +189,8 @@ Download a couple of templates into `roles/apache-simple/templates/`.  And right
 ```bash
 mkdir -p ~/apache-basic-playbook/roles/apache-simple/templates/
 cd ~/apache-basic-playbook/roles/apache-simple/templates/
-curl -O http://ansible-workshop.redhatgov.io/workshop-files/httpd.conf.j2
-curl -O http://ansible-workshop.redhatgov.io/workshop-files/index.html.j2
+curl -O http://ansible-workshop.rhdemo.io/workshop-files/httpd.conf.j2
+curl -O http://ansible-workshop.rhdemo.io/workshop-files/index.html.j2
 rm -rf ~/apache-basic-playbook/templates/
 ```
 

--- a/exercises/ansible_tower/4-security/README.md
+++ b/exercises/ansible_tower/4-security/README.md
@@ -42,7 +42,7 @@ Note the use of the [register](http://docs.ansible.com/ansible/latest/playbooks_
     scap_reports_dir: /tmp
     scap_profile: stig-rhel7-disa
   roles:
-    - rhtps.800-53 
+    - rhtps.800-53
 
   tasks:
     - name: determine the most recent scap report
@@ -139,7 +139,7 @@ You can watch the scan run against your managed node.  Note that each compliance
 Once the check is complete, you can open a new tab in your web browser, and navigate to the following URL, where `workshopname` is the workshop prefix, and `#` is the number that your instructor gave you:
 
 ```bash
-http://workshopname.node.#.redhatgov.io/scap
+http://workshopname.node.#.rhdemo.io/scap
 ```
 
 Click on the link called `scan-xccdf-report-...` to refiew the SCAP report that was generated.  Note the failures in the report; look at the machines, if you want, via your Wetty ssh session, to see what the problems might be.

--- a/exercises/ansible_tower/setup.md
+++ b/exercises/ansible_tower/setup.md
@@ -9,10 +9,10 @@ This lab provides a quick tour of the browser based SSH client Wetty. To help yo
 
 ## Accessing Wetty
 
-Use this URL to access the Wetty node, just change the workshopname. Ask your instructor for the workshopname. 
+Use this URL to access the Wetty node, just change the workshopname. Ask your instructor for the workshopname.
 
 ```bash
-https://<workshopname>.master.<student number>.redhatgov.io:8888
+https://<workshopname>.master.<student number>.rhdemo.io:8888
 ```
 
 After logging in, you should see a shell.


### PR DESCRIPTION
##### SUMMARY
this is removing of Red Hat public sector specific mentions per bug https://github.com/network-automation/linklight/issues/231

##### ISSUE TYPE
- Docs Pull Request


