### PR TITLE
Fix PROVISIONER SUMMARY private key path

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -194,7 +194,7 @@
           *******************
           - Workshop name is {{ec2_name_prefix}}
           - Instructor inventory is located at  {{playbook_dir}}/{{ec2_name_prefix}}/instructor_inventory.txt
-          - Private key is located at {{playbook_dir}}/{{ec2_name_prefix}}/{{ec2_name_prefix}}.pem
+          - Private key is located at {{playbook_dir}}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem
           {{website_information}}
           FAILURES
           *******************


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
    The current provisioner summary section provides a path that is
    incorrect. All task files in the manage_ec2_instances role for all
    lab types provision to '{{ec2_name_prefix}}-private.pem' so we
    should tell people to look there.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the role, task or feature below -->
manage_ec2_instances

