### PR TITLE
Added guidance to networking_v2 on v1 page

### DIFF
--- a/exercises/networking/README.ja.md
+++ b/exercises/networking/README.ja.md
@@ -1,5 +1,8 @@
 # Ansible Lightbulb - Networking
 
+このコンテンツは **廃止予定** です。最新版の [Ansible Linklight - Networking](../networking_v2/README.ja.md) を参照してください。
+
+
 このコンテンツは、Ansibleのネットワーク機器向け機能(Arista, Cisco, Cumulus, Juniper etc)の効果的なデモやワークショップトレーニング(講師による講義、ハンズあるいはセルフスタディ)の為の多目的ツールキットです。
 
 **Read this in other languages**: [![uk](../../images/uk.png) English](README.md),  [![uk](../../images/japan.png) 日本語](README.ja.md).

--- a/exercises/networking/README.md
+++ b/exercises/networking/README.md
@@ -1,6 +1,6 @@
 # Ansible Linklight - Networking
 
-This content has been **Deprecated**.  Please visit [workshop exercises page](../../) for more information.
+This content has been **Deprecated**.  Please refer the latest version of [Ansible Linklight - Networking](../networking_v2/README.md).
 
 This content is a multi-purpose toolkit for effectively demonstrating Ansible's capabilities on network equipment (Arista, Cisco, Cumulus, Juniper etc) or providing informal workshop training in various forms -- instructor-led, hands-on or self-paced.
 


### PR DESCRIPTION
##### SUMMARY
In the `networking v1` page, it should be better to guide to visit `networking_v2` page.

- Modified link to networking_2 in English
- Added introduction  to move on to networking_v2 in Japanese

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- networking

##### ADDITIONAL INFORMATION
None

