### PR TITLE
add cluster db port to sec group

### DIFF
--- a/provisioner/group_vars/all/vpc_rules.yml
+++ b/provisioner/group_vars/all/vpc_rules.yml
@@ -60,7 +60,11 @@ workshops:
         from_port: 514
         cidr_ip: 0.0.0.0/0
         rule_desc: WinRM
-
+      - proto: tcp
+        to_port: 5432
+        from_port: 5432
+        cidr_ip: 172.16.0.0/14
+        rule_desc: Cluster option DB port
   f5:
     ports:
       - proto: tcp


### PR DESCRIPTION
##### SUMMARY
The cluster option fails to deploy from devel. 

Reason: the PGSQL port is missing in the security group allow rules. Seems like it was accidentally removed during cleanup of rabbitmq rules. 

@liquidat @termlen0 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

