### PR TITLE
manage_ec2_instances role: overwrite select 'ec2_info' vars via 'ex2_xtra'

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -84,6 +84,16 @@ controllerinstall: true
 
 # forces ansible.workshops collection to install latest edits every time
 developer_mode: true
+
+# default vars for ec2 AMIs (ec2_info) are located in provisioner/roles/manage_ec2_instances/defaults/main/main.yml
+# select ec2_info AMI vars can be overwritten via ec2_xtra vars, e.g.:
+ec2_xtra:
+  satellite:
+    owners: 012345678910
+    filter: Satellite*
+    username: ec2-user
+    os_type: linux
+    size: r5b.2xlarge
 ```
 
 If you want to license it you must copy a license called tower_license.json into this directory.  If you do not have a license already please request one using the [Workshop License Link](https://www.ansible.com/workshop-license).

--- a/provisioner/roles/manage_ec2_instances/tasks/main.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: overwrite select ec2_info vars if ec2_xtra vars are provided
+  set_fact:
+    ec2_info: '{{ ec2_info|combine(ec2_xtra) }}'
+  when: (ec2_xtra is defined) and (ec2_xtra is not none)
+
 - include_tasks: teardown.yml
   when: teardown|bool
 


### PR DESCRIPTION
##### SUMMARY
In order to overwrite default `ec2_info` vars in the manage_ec2_instances role via extra_vars config file, even if for a single AMI definition, the entire list of `ec2_info` vars would need to be included in the extra_vars file.  By providing an alternate mechanism for overwriting select `ec2_info` AMI vars, an easier method of providing customized deployment scenarios is achieved, especially for automation frameworks utilizing the ansible/workshops provisioner.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner
