### PR TITLE
fixing collections_path to avoid conflicts for GPTE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Gemfile
 _site/*
 .tox/
 provisioner/tests/ci-common.yml
+provisioner/workshop_collections/*
 *.gz
 provisioner/old_tower_license.json
 .cache/

--- a/provisioner/ansible.cfg
+++ b/provisioner/ansible.cfg
@@ -8,6 +8,7 @@
 # finds first
 
 [defaults]
+collections_path = workshop_collections
 interpreter_python = auto_silent
 stdout_callback = community.general.yaml
 inventory      = hosts

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -1,5 +1,5 @@
 ---
-- name: Perform Checks to make sure this playbook will complete successfully
+- name: setup collections for ansible.workshops
   hosts: localhost
   connection: local
   become: false
@@ -17,6 +17,7 @@
     - name: retrieve installed ansible.workshops collection
       shell: ansible-galaxy collection list | grep ansible.workshops
       register: installed_version
+      ignore_errors: true
 
     - name: compare galaxy.yml to installed version
       set_fact:
@@ -40,17 +41,23 @@
             state: absent
             path: build
 
-    - name: run pre-check role to make sure workshop will complete provisioning
-      include_role:
-        name: ansible.workshops.workshop_check_setup
+    - name: workshop collection final check
+      block:
+        - name: run pre-check role to make sure workshop will complete provisioning
+          include_role:
+            name: ansible.workshops.workshop_check_setup
 
-    - name: run AWS check setup if using AWS
-      include_role:
-        name: ansible.workshops.aws_check_setup
+        - name: run AWS check setup if using AWS
+          include_role:
+            name: ansible.workshops.aws_check_setup
 
-    - name: download AAP
-      include_role:
-        name: ansible.workshops.aap_download
+        - name: download AAP
+          include_role:
+            name: ansible.workshops.aap_download
+      rescue:
+        - name: Example using fail and when together
+          fail:
+            msg: If you have recieved a 'was not found' error please re-run the provisioner.  Collections can only be updated, not installed, within the same Ansible play.  If you still have an issue with your workshop setup on your control node, please open an issue on https://github.com/ansible/workshops
 
 - name: Create lab instances in AWS
   hosts: localhost

--- a/provisioner/teardown_lab.yml
+++ b/provisioner/teardown_lab.yml
@@ -17,6 +17,7 @@
     - name: retrieve installed ansible.workshops collection
       shell: ansible-galaxy collection list | grep ansible.workshops
       register: installed_version
+      ignore_errors: true
 
     - name: compare galaxy.yml to installed version
       set_fact:
@@ -27,7 +28,7 @@
         var: match_galaxy_version
 
     - name: install missing collections
-      when: not match_galaxy_version
+      when: not match_galaxy_version or developer_mode
       block:
         - name: build workshop into collection
           shell: "ansible-galaxy collection build --verbose --force --output-path build/ {{ playbook_dir }}/.."
@@ -39,6 +40,20 @@
           file:
             state: absent
             path: build
+
+    - name: workshop collection final check
+      block:
+        - name: run pre-check role to make sure workshop will complete provisioning
+          include_role:
+            name: ansible.workshops.workshop_check_setup
+
+        - name: run AWS check setup if using AWS
+          include_role:
+            name: ansible.workshops.aws_check_setup
+      rescue:
+        - name: Example using fail and when together
+          fail:
+            msg: If you have recieved a 'was not found' error please re-run the provisioner.  Collections can only be updated, not installed, within the same Ansible play.  If you still have an issue with your workshop setup on your control node, please open an issue on https://github.com/ansible/workshops
 
 - name: Destroy lab instances in AWS
   hosts: localhost


### PR DESCRIPTION
##### SUMMARY
discussed in internal red hat Ansible Workshops & Demos Google chat


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
What we can't do->
- we can't dynamically change the location of collections path mid-play (during an execution of ansible-playbook/ansible-navigator)
- we can't install a collection on demand (it will show missing.... it only does this once at the beginning of the first play)
- there is no way to dynamically include a play and/or playbook (you can do include tasks, but there has never been support for dynamically including an entire play)

What we can do->
- We can UPDATE a collection mid-play (which we were doing... so that makes sense)
- I can set a path PER catalog item, so all AAP2 workshops will use workshops_collections path inside itself (testing now and it seems to work fine), this should avoid all conflicts with other catalog items and ansible labs