### PR TITLE
Updated RDP link to https

### DIFF
--- a/exercises/ansible_security/1.2-checkpoint/README.md
+++ b/exercises/ansible_security/1.2-checkpoint/README.md
@@ -99,7 +99,7 @@ The Windows workstation can be reached via Remote Desktop Protocol (RDP). We rec
 
 Test the access to the MGMT server now by pointing your RDP client to the `windows-ws` IP in your inventory.
 
-If you do not have a RDP client available or want to test the HTML RDP client, please open the following URL in your browser: `http://<windows-wsIP>/myrtille`. Be sure to replace `<windows-wsIP>` with the IP for the Windows workstation from your inventory. In the login field, only provide the user name and the password: The user name is **Administrator**, the password is provided in the inventory. Leave the other fields empty, and click on **Connect**.
+If you do not have a RDP client available or want to test the HTML RDP client, please open the following URL in your browser: `https://<windows-wsIP>/myrtille`. Be sure to replace `<windows-wsIP>` with the IP for the Windows workstation from your inventory. In the login field, only provide the user name and the password: The user name is **Administrator**, the password is provided in the inventory. Leave the other fields empty, and click on **Connect**.
 
 You now are accessing a default windows workstation with a Google Chrome browser installed.
 


### PR DESCRIPTION
##### SUMMARY
Fixes #1116

**Exercise 1.2 - Checkpoint: Step 2.2**
- Updated Windows RDP link to  https ( `https://<windows-wsIP>/myrtille` )

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- exercises
