### PR TITLE
fix windows ToC

### DIFF
--- a/exercises/ansible_windows/README.md
+++ b/exercises/ansible_windows/README.md
@@ -27,7 +27,7 @@ If your experience is different in scheduling these workshops, please let us kno
 
 ## Exercises
 
-* [Exercise 1 - Intro and configuration of Automation Controller](1-tower)
+* [Exercise 1 - Intro and configuration of Automation Controller](1-controller)
 * [Exercise 2 - Ad-hoc commands](2-adhoc)
 * [Exercise 3 - Intro to playbooks](3-playbook)
 * [Exercise 4 - Automation Controller projects](4-projects)


### PR DESCRIPTION
##### SUMMARY
There is a typo in the Windows ToC - the directory was renamed to `1-controller`, but the ToC is still using `1-tower`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- docs
