### PR TITLE
fixing all the linting issues

### DIFF
--- a/exercises/ansible_rhel/ansible-files/files/check_httpd.yml
+++ b/exercises/ansible_rhel/ansible-files/files/check_httpd.yml
@@ -3,7 +3,7 @@
   hosts: control
   vars:
     node: "node1"
-  
+
   tasks:
     - name: Check that you can connect (GET) to a page and it returns a status 200
       uri:

--- a/exercises/ansible_rhel/ansible-files/files/service_state.yml
+++ b/exercises/ansible_rhel/ansible-files/files/service_state.yml
@@ -4,7 +4,7 @@
   become: true
   vars:
     package: "httpd"
-  
+
   tasks:
     - name: Check status of {{ package }} service
       service_facts:

--- a/exercises/ansible_rhel/ansible-files/files/setup.yml
+++ b/exercises/ansible_rhel/ansible-files/files/setup.yml
@@ -1,14 +1,14 @@
 ---
 - name: Capture Setup
   hosts: node1
-  
+
   tasks:
 
     - name: Collect only facts returned by facter
       ansible.builtin.setup:
         gather_subset:
-        - 'all'
+          - 'all'
       register: setup
-    
+
     - debug:
         var: setup


### PR DESCRIPTION
##### SUMMARY
should fix the following->

```
[3110] /home/zuul/src/github.com/ansible/workshops$ /home/zuul/src/github.com/ansible/workshops/.tox/linters/bin/yamllint -s .
./exercises/ansible_rhel/ansible-files/files/service_state.yml
  7:1       error    trailing spaces  (trailing-spaces)

./exercises/ansible_rhel/ansible-files/files/check_httpd.yml
  6:1       error    trailing spaces  (trailing-spaces)

./exercises/ansible_rhel/ansible-files/files/setup.yml
  4:1       error    trailing spaces  (trailing-spaces)
  10:9      error    wrong indentation: expected 10 but found 8  (indentation)
  12:1      error    trailing spaces  (trailing-spaces)

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises



##### ADDITIONAL INFORMATION
making sure we can pass yamllint, because @rlopez133 was cruel 
