### PR TITLE
Provide additional threads, retry until not failed

### DIFF
--- a/roles/control_node/tasks/30_controller.yml
+++ b/roles/control_node/tasks/30_controller.yml
@@ -104,6 +104,13 @@
     registry: registry.redhat.io
   become_user: "awx"
 
+- name: Mod containers.conf to utilize max of 10 parallel threads
+  become_user: "awx"
+  lineinfile:
+    path: /var/lib/awx/.config/containers/containers.conf
+    line: 'image_parallel_copies=10'
+    insertafter: EOF
+
 - name: Pull supported images
   become_user: "awx"
   containers.podman.podman_image:
@@ -112,12 +119,20 @@
     - "registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0"
     - "registry.redhat.io/ansible-automation-platform-20-early-access/ee-29-rhel8:2.0.0"
     - "registry.redhat.io/ansible-automation-platform-20-early-access/ee-minimal-rhel8:2.0.0"
+  register: podman_pull_supported
+  until: podman_pull_supported is not failed
+  retries: 5
+  delay: 15
 
 - name: Pull workshop images
   become_user: "awx"
   containers.podman.podman_image:
     name: "{{ lookup('vars', workshop_type + '_ee') }}"
   when: workshop_type is defined
+  register: podman_pull_workshop
+  until: podman_pull_workshop is not failed
+  retries: 5
+  delay: 15
 
 - name: create container registry credential
   awx.awx.credential:


### PR DESCRIPTION
##### SUMMARY
Provisioner can intermittently fail during image pulls with "Failed to pull image" message. Additionally, when adding Projects to controller, "Project update failed" message can occur.  Occasionally, the underlying error is "Error: Error writing blob to file "/var/tmp/storage/storage304273906/1": error happened during read: unexpected EOF

Research on this issue: lead to similar issue being reported in buildah project for container engine pulls: http://github.com/containers/buildah/issues/2224
Ultimately, containers.conf was "wired up" to allow raising the number of threads for simultaneous image layer copies (pulled/pushed).

Raising container engine parallel threads from 6 to 10 and adding retries until not failed for associated image pull tasks to resolve the issue.

##### ISSUE TYPE
- Bugfix Pull Request for [Issue 1394](https://github.com/ansible/workshops/issues/1394)

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
To reproduce, deploy a 50 student workshop multiple times over the period of the day, you will experience intermittent failures on a small percentage of controllers.