### PR TITLE
"next exercise" navigation broken on RHEL workshop

### DIFF
--- a/exercises/ansible_rhel/1.1-setup/README.md
+++ b/exercises/ansible_rhel/1.1-setup/README.md
@@ -145,7 +145,13 @@ You will soon discover that many chapters in this lab guide come with a "Challen
 
 ---
 **Navigation**
+
 <br>
+
+{% if page.url contains 'ansible_rhel_90' %}
 [Next Exercise](../2-thebasics)
+{% else %}
+[Next Exercise](../1.2-thebasics)
+{% endif %}
 <br><br>
 [Click here to return to the Ansible for Red Hat Enterprise Linux Workshop](../README.md)


### PR DESCRIPTION
##### SUMMARY
The "next exercise" link at the bottom navigation is broken. I copied this over from `exercises/ansible_rhel_90/1-setup/README.md`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises
