### PR TITLE
Fixing changes for proper rendering of gh-pages and fixing playbook to match ansible-files check_httpd.yml

### DIFF
--- a/exercises/ansible_rhel/1.3-playbook/README.md
+++ b/exercises/ansible_rhel/1.3-playbook/README.md
@@ -338,20 +338,23 @@ Notice in the output, we see the play had `1` "CHANGED" shown in yellow and if w
 
 ### Step 5 - Extend your Playbook: Create an web.html
 
-Check that the tasks were executed correctly and Apache is accepting connections: Make an HTTP request using Ansible’s `uri` module in a playbook named check_httpd.yml from the control node. Make sure to replace the **\<IP\>** with the IP for the `node1` from the inventory.
+Check that the tasks were executed correctly and Apache is accepting connections: Make an HTTP request using Ansible’s `uri` module in a playbook named check_httpd.yml from the control node to `node1`. 
 
+{% raw %}
 ```yaml
 ---
 - name: Check URL
   hosts: control
   vars:
-    IP: "IP_OF_NODE1"
+    node: "node1"
 
   tasks:
     - name: Check that you can connect (GET) to a page and it returns a status 200
       uri:
-        url: "http://{{ IP }}"
+        url: "http://{{ node }}"
+
 ```
+{% endraw %}
 
 > **Warning**
 >


### PR DESCRIPTION

##### SUMMARY
Adding raw and endraw to syntax for proper gh pages rendering. Also fixed the playbook check_httpd to match the ansible-files. 

Fixes: #1396 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- docs
