### PR TITLE
Add FQCN where is needed in the English README

### DIFF
--- a/exercises/ansible_rhel/1.3-playbook/README.md
+++ b/exercises/ansible_rhel/1.3-playbook/README.md
@@ -110,7 +110,7 @@ Now that we've defined the play, let's add a task to get something done. We will
   become: yes
   tasks:
   - name: latest Apache version installed
-    yum:
+    ansible.builtin.yum:
       name: httpd
       state: latest
 ```
@@ -285,11 +285,11 @@ On the control host, as your student user, edit the file `~/ansible-files/apache
   become: yes
   tasks:
   - name: latest Apache version installed
-    yum:
+    ansible.builtin.yum:
       name: httpd
       state: latest
   - name: Apache enabled and running
-    service:
+    ansible.builtin.service:
       name: httpd
       enabled: true
       state: started
@@ -326,10 +326,10 @@ Notice in the output, we see the play had `1` "CHANGED" shown in yellow and if w
 
   tasks:
     - name: Check status of {{ package }} service
-      service_facts:
+      ansible.builtin.service_facts:
       register: service_state
 
-    - debug:
+    - ansible.builtin.debug:
         var: service_state.ansible_facts.services["{{ package }}.service"].state
 ```
 
@@ -353,7 +353,7 @@ Check that the tasks were executed correctly and Apache is accepting connections
 
   tasks:
     - name: Check that you can connect (GET) to a page and it returns a status 200
-      uri:
+      ansible.builtin.uri:
         url: "http://{{ node }}"
 
 ```
@@ -394,16 +394,16 @@ On the control node as your student user edit the file `~/ansible-files/apache.y
   become: yes
   tasks:
   - name: latest Apache version installed
-    yum:
+    ansible.builtin.yum:
       name: httpd
       state: latest
   - name: Apache enabled and running
-    service:
+    ansible.builtin.service:
       name: httpd
       enabled: true
       state: started
   - name: copy web.html
-    copy:
+    ansible.builtin.copy:
       src: web.html
       dest: /var/www/html/index.html
 ```
@@ -448,16 +448,16 @@ Change the playbook `hosts` parameter to point to `web` instead of `node1`:
   become: yes
   tasks:
   - name: latest Apache version installed
-    yum:
+    ansible.builtin.yum:
       name: httpd
       state: latest
   - name: Apache enabled and running
-    service:
+    ansible.builtin.service:
       name: httpd
       enabled: true
       state: started
   - name: copy web.html
-    copy:
+    ansible.builtin.copy:
       src: web.html
       dest: /var/www/html/index.html
 ```

--- a/exercises/ansible_rhel/1.4-variables/README.md
+++ b/exercises/ansible_rhel/1.4-variables/README.md
@@ -122,7 +122,7 @@ Create a new Playbook called `deploy_index_html.yml` in the `~/ansible-files/` d
   become: true
   tasks:
   - name: copy web.html
-    copy:
+    ansible.builtin.copy:
       src: "{{ stage }}_web.html"
       dest: /var/www/html/index.html
 ```
@@ -189,7 +189,7 @@ To get an idea what facts Ansible collects by default, on your control node as y
         - 'all'
       register: setup
 
-    - debug:
+    - ansible.builtin.debug:
         var: setup
 ```
 
@@ -247,7 +247,7 @@ This might be a bit too much, you can use filters to limit the output to certain
         - '*distribution'
       register: setup
 
-    - debug:
+    - ansible.builtin.debug:
         var: setup
 ```
 
@@ -299,7 +299,7 @@ Facts can be used in a Playbook like variables, using the proper naming, of cour
   hosts: all
   tasks:
   - name: Prints Ansible facts
-    debug:
+    anisble.builtin.debug:
       msg: The default IPv4 address of {{ ansible_fqdn }} is {{ ansible_default_ipv4.address }}
 ```
 

--- a/exercises/ansible_rhel/1.5-handlers/README.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.md
@@ -79,7 +79,7 @@ Next create the file `ftpserver.yml` on your control host in the `~/ansible-file
   become: true
   tasks:
     - name: Install FTP server when host in ftpserver group
-      yum:
+      ansible.builtin.um:
         name: vsftpd
         state: latest
       when: inventory_hostname in groups["ftpserver"]
@@ -126,14 +126,14 @@ Next, create the Playbook `httpd_conf.yml`. Make sure that you are in the direct
   become: true
   tasks:
   - name: Copy Apache configuration file
-    copy:
+    ansible.builtin.copy:
       src: httpd.conf
       dest: /etc/httpd/conf/
     notify:
       - restart_apache
   handlers:
     - name: restart_apache
-      service:
+      ansible.builtin.service:
         name: httpd
         state: restarted
 ```
@@ -187,7 +187,7 @@ To show the loops feature we will generate three new users on `node1`. For that,
 
   tasks:
     - name: Ensure three users are present
-      user:
+      ansible.builtin.user:
         name: "{{ item }}"
         state: present
       loop:
@@ -235,7 +235,7 @@ Let's rewrite the playbook to create the users with additional user rights:
 
   tasks:
     - name: Ensure three users are present
-      user:
+      ansible.builtin.user:
         name: "{{ item.username }}"
         state: present
         groups: "{{ item.groups }}"
@@ -263,10 +263,10 @@ Verify that the user `dev_user` was indeed created on `node1` using the followin
     myuser: "dev_user"
   tasks:
     - name: Get {{ myuser }} info
-      getent:
+      ansible.builtin.getent:
         database: passwd
         key: "{{ myuser }}"
-    - debug:
+    - ansible.builtin.debug:
         msg:
           - "{{ myuser }} uid: {{ getent_passwd[myuser].1 }}"
 ```

--- a/exercises/ansible_rhel/1.6-templates/README.md
+++ b/exercises/ansible_rhel/1.6-templates/README.md
@@ -50,7 +50,7 @@ Next we need a playbook to use this template. In the `~/ansible-files/` director
   hosts: node1
   become: true
   tasks:
-    - template:
+    - ansible.builtin.template:
         src: motd-facts.j2
         dest: /etc/motd
         owner: root
@@ -104,7 +104,7 @@ Add a line to the template to list the current kernel of the managed node.
         - '*kernel'
       register: setup
 
-    - debug:
+    - ansible.builtin.debug:
         var: setup
 ```
 

--- a/exercises/ansible_rhel/1.7-role/README.md
+++ b/exercises/ansible_rhel/1.7-role/README.md
@@ -136,12 +136,12 @@ Edit the `roles/apache_vhost/tasks/main.yml` file:
 ```yaml
 ---
 - name: install httpd
-  yum:
+  ansible.builtin.yum:
     name: httpd
     state: latest
 
 - name: start and enable httpd service
-  service:
+  ansible.builtin.service:
     name: httpd
     state: started
     enabled: true
@@ -160,12 +160,12 @@ Next we add two more tasks to ensure a vhost directory structure and copy html c
 
 ```yaml
 - name: ensure vhost directory is present
-  file:
+  ansible.builtin.file:
     path: "/var/www/vhosts/{{ ansible_hostname }}"
     state: directory
 
 - name: deliver html content
-  copy:
+  ansible.builtin.copy:
     src: web.html
     dest: "/var/www/vhosts/{{ ansible_hostname }}/index.html"
 ```
@@ -178,7 +178,7 @@ The last task we add uses the template module to create the vhost configuration 
 
 ```yaml
 - name: template vhost file
-  template:
+  ansible.builtin.template:
     src: vhost.conf.j2
     dest: /etc/httpd/conf.d/vhost.conf
     owner: root
@@ -197,28 +197,28 @@ The full `tasks/main.yml` file is:
 ```yaml
 ---
 - name: install httpd
-  yum:
+  ansible.builtin.yum:
     name: httpd
     state: latest
 
 - name: start and enable httpd service
-  service:
+  ansible.builtin.service:
     name: httpd
     state: started
     enabled: true
 
 - name: ensure vhost directory is present
-  file:
+  ansible.builtin.file:
     path: "/var/www/vhosts/{{ ansible_hostname }}"
     state: directory
 
 - name: deliver html content
-  copy:
+  ansible.builtin.copy:
     src: web.html
     dest: "/var/www/vhosts/{{ ansible_hostname }}/index.html"
 
 - name: template vhost file
-  template:
+  ansible.builtin.template:
     src: vhost.conf.j2
     dest: /etc/httpd/conf.d/vhost.conf
     owner: root
@@ -238,7 +238,7 @@ Create the handler in the file `roles/apache_vhost/handlers/main.yml` to restart
 ---
 # handlers file for roles/apache_vhost
 - name: restart_httpd
-  service:
+  ansible.builtin.service:
     name: httpd
     state: restarted
 ```
@@ -290,14 +290,14 @@ You are ready to test the role against `node2`. But since a role cannot be assig
   become: true
 
   pre_tasks:
-    - debug:
+    - ansible.builtin.debug:
         msg: 'Beginning web server configuration.'
 
   roles:
     - apache_vhost
 
   post_tasks:
-    - debug:
+    - ansible.builtin.debug:
         msg: 'Web server has been configured.'
 ```
 

--- a/exercises/ansible_rhel/2.3-projects/README.md
+++ b/exercises/ansible_rhel/2.3-projects/README.md
@@ -40,30 +40,30 @@ A playbook to install the Apache web server has already been committed to the di
 
   tasks:
   - name: latest Apache version installed
-    yum:
+    ansible.builtin.yum:
       name: httpd
       state: latest
 
   - name: latest firewalld version installed
-    yum:
+    ansible.builtin.yum:
       name: firewalld
       state: latest
 
   - name: firewalld enabled and running
-    service:
+    ansible.builtin.service:
       name: firewalld
       enabled: true
       state: started
 
   - name: firewalld permits http service
-    firewalld:
+    ansible.builtin.firewalld:
       service: http
       permanent: true
       state: enabled
       immediate: yes
 
   - name: Apache enabled and running
-    service:
+    ansible.builtin.service:
       name: httpd
       enabled: true
       state: started


### PR DESCRIPTION
Implement collections as FQCN on plays where is missed, to get compatible with Ansible 2.10

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes the FQCN in the plays that were missing on the English README files

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- docs


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
