### PR TITLE
LetsEncrypt certificate issuance via podman/certbot container

### DIFF
--- a/roles/control_node/tasks/15_package_dependencies.yml
+++ b/roles/control_node/tasks/15_package_dependencies.yml
@@ -1,10 +1,4 @@
 ---
-- name: Install EPEL
-  dnf:
-    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-    state: present
-    disable_gpg_check: true
-
 - name: Install base packages
   dnf:
     name:
@@ -27,23 +21,3 @@
   until: dnf_check is not failed
   retries: 4
   delay: 5
-
-# Certbot dependancy / acme, needs later version of requests library than task above^^
-- name: install awxkit and requests >2.14
-  become: true
-  ansible.builtin.pip:
-    name:
-      - awxkit
-      - yamllint
-      - "requests==2.14.2"
-      - ansible-navigator
-      - ansible-lint
-    state: latest
-
-- name: install community collection
-  shell: "ansible-galaxy collection install {{ item }} --force-with-deps "
-  register: controlnode
-  loop:
-    - community.general
-  until: controlnode is not failed
-  retries: 5

--- a/roles/issue_cert/tasks/main.yml
+++ b/roles/issue_cert/tasks/main.yml
@@ -4,22 +4,6 @@
     - name: controller start
       include_tasks: "service/controller_start.yml"
 
-    # directions found here https://certbot.eff.org/lets-encrypt/centosrhel8-other
-    - name: install certbot if not already installed
-      dnf:
-        name: certbot
-        state: present
-        disable_gpg_check: true
-    # solves error
-    # pkg_resources.DistributionNotFound: The 'requests>=2.14.2' distribution was not found and is required by acme
-    - name: Install requests python package
-      pip:
-        name: requests>=2.14.2
-
-    - name: Install requests python package
-      pip:
-        name: requests>=2.14.2
-
     - &tower-pinger-block
       block:
         - name: check Tower status
@@ -59,13 +43,38 @@
     - name: controller stop
       include_tasks: "service/controller_stop.yml"
 
+    - name: create letsencrypt subdirectories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: root
+        group: root
+        mode: 0750
+      with_items:
+        - /etc/letsencrypt
+        - /var/lib/letsencrypt
+
     # If this fails check out status of certbot: https://letsencrypt.status.io/
     - name: try to issue SSL certificate
       block:
         - name: Issue SSL cert
-          shell: certbot certonly --no-bootstrap --standalone -d {{ dns_name }} --email ansible-network@redhat.com --noninteractive --agree-tos
-          register: issue_cert
-          until: issue_cert is not failed
+          shell: >
+            podman run -it --rm --name certbot \
+                -v "/etc/letsencrypt:/etc/letsencrypt" \
+                -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
+                -p 80:80 \
+                -p 443:443 \
+                docker.io/certbot/certbot:latest certonly \
+                --key-type rsa \
+                --rsa-key-size 4096 \
+                --no-bootstrap \
+                --standalone \
+                -d {{ dns_name }} \
+                --email ansible-network@redhat.com \
+                --noninteractive \
+                --agree-tos
+          register: issue_controller_cert
+          until: issue_controller_cert is not failed
           retries: 5
       rescue:
         - name: error with SSL cert
@@ -77,22 +86,51 @@
             dns_information:
               - "{{ dns_information }}"
               - "The Lets Encrypt certbot failed for the controller node, please check https://letsencrypt.status.io/ to make sure the service is running"
+    - name: download LetsEncrypt R3 cert
+      get_url:
+        url: https://letsencrypt.org/certs/lets-encrypt-r3.pem
+        dest: "/etc/letsencrypt/live/{{ dns_name }}"
+        mode: 0644
+        checksum: sha256:177e1b8fc43b722b393f4200ff4d92e32deeffbb76fef5ee68d8f49c88cf9d32
+        group: root
+        owner: root
+    - name: download LetsEncrypt root X1 cert
+      get_url:
+        url: https://letsencrypt.org/certs/isrgrootx1.pem
+        dest: "/etc/letsencrypt/live/{{ dns_name }}"
+        mode: 0644
+        checksum: sha256:22b557a27055b33606b6559f37703928d3e4ad79f110b407d04986e1843543d1
+        group: root
+        owner: root
+    - name: retrieve LetsEncrypt R3 cert
+      slurp:
+        src: "/etc/letsencrypt/live/{{ dns_name }}/lets-encrypt-r3.pem"
+      register: intermediate_cert
+    - name: retrieve LetsEncrypt root X1 cert
+      slurp:
+        src: "/etc/letsencrypt/live/{{ dns_name }}/isrgrootx1.pem"
+      register: root_cert
+    - name: combine R3 and root X1 certs to create LetsEncrypt CA bundle
+      template:
+        src: cert_bundle.j2
+        dest: "/etc/letsencrypt/live/{{ dns_name }}/letsencrypt-ca-bundle.pem"
 
-    - name: Move SSL Key
-      copy:
-        remote_src: true
+    - name: Symlink LetsEncrypt CA bundle to /etc/tower/tower.cert
+      ansible.builtin.file:
+        src: "/etc/letsencrypt/live/{{ dns_name }}/letsencrypt-ca-bundle.pem"
+        dest: /etc/tower/tower.cert
+        owner: root
+        group: root
+        state: link
+
+    - name: Symlink LetsEncrypt generated private key to /etc/tower/tower.key
+      ansible.builtin.file:
         src: "/etc/letsencrypt/live/{{ dns_name }}/privkey.pem"
         dest: /etc/tower/tower.key
+        owner: root
+        group: root
+        state: link
 
-    - name: Retrieve Specific SSL Cert
-      slurp:
-        src: "/etc/letsencrypt/live/{{ dns_name }}/cert.pem"
-      register: intermediate_cert
-
-    - name: Combine Specific and intermediate Cert
-      template:
-        src: combined_cert.j2
-        dest: /etc/tower/tower.cert
   rescue:
     - name: no SSL cert for Automation Controller
       debug:
@@ -101,3 +139,4 @@
     # Turn on Ansible Controller if successful
     - name: controller restart
       include_tasks: "service/controller_start.yml"
+...

--- a/roles/issue_cert/tasks/main.yml
+++ b/roles/issue_cert/tasks/main.yml
@@ -122,16 +122,14 @@
         dest: /etc/tower/tower.cert
         owner: root
         group: awx
-        state: link
-
+        remote_src: true
     - name: Symlink LetsEncrypt generated private key to /etc/tower/tower.key
       ansible.builtin.file:
         src: "/etc/letsencrypt/live/{{ dns_name }}/privkey.pem"
         dest: /etc/tower/tower.key
         owner: root
         group: awx
-        state: link
-
+        remote_src: true
   rescue:
     - name: no SSL cert for Automation Controller
       debug:

--- a/roles/issue_cert/tasks/main.yml
+++ b/roles/issue_cert/tasks/main.yml
@@ -76,6 +76,8 @@
           register: issue_controller_cert
           until: issue_controller_cert is not failed
           retries: 5
+          become: true
+          become_method: sudo
       rescue:
         - name: error with SSL cert
           debug:

--- a/roles/issue_cert/tasks/main.yml
+++ b/roles/issue_cert/tasks/main.yml
@@ -47,8 +47,8 @@
       file:
         path: "{{ item }}"
         state: directory
-        owner: awx
-        group: awx
+        owner: root
+        group: root
         mode: 0750
       with_items:
         - /etc/letsencrypt
@@ -76,9 +76,6 @@
           register: issue_controller_cert
           until: issue_controller_cert is not failed
           retries: 5
-          become: true
-          become_method: sudo
-          become_user: awx
       rescue:
         - name: error with SSL cert
           debug:
@@ -95,16 +92,16 @@
         dest: "/etc/letsencrypt/live/{{ dns_name }}"
         mode: 0644
         checksum: sha256:177e1b8fc43b722b393f4200ff4d92e32deeffbb76fef5ee68d8f49c88cf9d32
-        group: awx
-        owner: awx
+        group: root
+        owner: root
     - name: download LetsEncrypt root X1 cert
       get_url:
         url: https://letsencrypt.org/certs/isrgrootx1.pem
         dest: "/etc/letsencrypt/live/{{ dns_name }}"
         mode: 0644
         checksum: sha256:22b557a27055b33606b6559f37703928d3e4ad79f110b407d04986e1843543d1
-        group: awx
-        owner: awx
+        group: root
+        owner: root
     - name: retrieve LetsEncrypt R3 cert
       slurp:
         src: "/etc/letsencrypt/live/{{ dns_name }}/lets-encrypt-r3.pem"
@@ -117,8 +114,8 @@
       template:
         src: cert_bundle.j2
         dest: "/etc/letsencrypt/live/{{ dns_name }}/letsencrypt-ca-bundle.pem"
-        group: awx
-        owner: awx
+        group: root
+        owner: root
     - name: Symlink LetsEncrypt CA bundle to /etc/tower/tower.cert
       ansible.builtin.file:
         src: "/etc/letsencrypt/live/{{ dns_name }}/letsencrypt-ca-bundle.pem"

--- a/roles/issue_cert/tasks/main.yml
+++ b/roles/issue_cert/tasks/main.yml
@@ -117,14 +117,14 @@
         group: root
         owner: root
     - name: Symlink LetsEncrypt CA bundle to /etc/tower/tower.cert
-      ansible.builtin.file:
+      ansible.builtin.copy:
         src: "/etc/letsencrypt/live/{{ dns_name }}/fullchain.pem"
         dest: /etc/tower/tower.cert
         owner: root
         group: awx
         remote_src: true
     - name: Symlink LetsEncrypt generated private key to /etc/tower/tower.key
-      ansible.builtin.file:
+      ansible.builtin.copy:
         src: "/etc/letsencrypt/live/{{ dns_name }}/privkey.pem"
         dest: /etc/tower/tower.key
         owner: root

--- a/roles/issue_cert/tasks/main.yml
+++ b/roles/issue_cert/tasks/main.yml
@@ -60,8 +60,8 @@
         - name: Issue SSL cert
           shell: >
             podman run -it --rm --name certbot \
-                -v "/etc/letsencrypt:/etc/letsencrypt" \
-                -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
+                -v "/etc/letsencrypt:/etc/letsencrypt:z" \
+                -v "/var/lib/letsencrypt:/var/lib/letsencrypt:z" \
                 -p 80:80 \
                 -p 443:443 \
                 docker.io/certbot/certbot:latest certonly \
@@ -76,8 +76,6 @@
           register: issue_controller_cert
           until: issue_controller_cert is not failed
           retries: 5
-          become: true
-          become_method: sudo
       rescue:
         - name: error with SSL cert
           debug:

--- a/roles/issue_cert/tasks/main.yml
+++ b/roles/issue_cert/tasks/main.yml
@@ -118,7 +118,7 @@
         owner: root
     - name: Symlink LetsEncrypt CA bundle to /etc/tower/tower.cert
       ansible.builtin.file:
-        src: "/etc/letsencrypt/live/{{ dns_name }}/letsencrypt-ca-bundle.pem"
+        src: "/etc/letsencrypt/live/{{ dns_name }}/fullchain.pem"
         dest: /etc/tower/tower.cert
         owner: root
         group: awx

--- a/roles/issue_cert/tasks/main.yml
+++ b/roles/issue_cert/tasks/main.yml
@@ -47,8 +47,8 @@
       file:
         path: "{{ item }}"
         state: directory
-        owner: root
-        group: root
+        owner: awx
+        group: awx
         mode: 0750
       with_items:
         - /etc/letsencrypt
@@ -76,6 +76,9 @@
           register: issue_controller_cert
           until: issue_controller_cert is not failed
           retries: 5
+          become: true
+          become_method: sudo
+          become_user: awx
       rescue:
         - name: error with SSL cert
           debug:
@@ -92,16 +95,16 @@
         dest: "/etc/letsencrypt/live/{{ dns_name }}"
         mode: 0644
         checksum: sha256:177e1b8fc43b722b393f4200ff4d92e32deeffbb76fef5ee68d8f49c88cf9d32
-        group: root
-        owner: root
+        group: awx
+        owner: awx
     - name: download LetsEncrypt root X1 cert
       get_url:
         url: https://letsencrypt.org/certs/isrgrootx1.pem
         dest: "/etc/letsencrypt/live/{{ dns_name }}"
         mode: 0644
         checksum: sha256:22b557a27055b33606b6559f37703928d3e4ad79f110b407d04986e1843543d1
-        group: root
-        owner: root
+        group: awx
+        owner: awx
     - name: retrieve LetsEncrypt R3 cert
       slurp:
         src: "/etc/letsencrypt/live/{{ dns_name }}/lets-encrypt-r3.pem"
@@ -114,13 +117,14 @@
       template:
         src: cert_bundle.j2
         dest: "/etc/letsencrypt/live/{{ dns_name }}/letsencrypt-ca-bundle.pem"
-
+        group: awx
+        owner: awx
     - name: Symlink LetsEncrypt CA bundle to /etc/tower/tower.cert
       ansible.builtin.file:
         src: "/etc/letsencrypt/live/{{ dns_name }}/letsencrypt-ca-bundle.pem"
         dest: /etc/tower/tower.cert
         owner: root
-        group: root
+        group: awx
         state: link
 
     - name: Symlink LetsEncrypt generated private key to /etc/tower/tower.key
@@ -128,7 +132,7 @@
         src: "/etc/letsencrypt/live/{{ dns_name }}/privkey.pem"
         dest: /etc/tower/tower.key
         owner: root
-        group: root
+        group: awx
         state: link
 
   rescue:

--- a/roles/issue_cert/templates/cert_bundle.j2
+++ b/roles/issue_cert/templates/cert_bundle.j2
@@ -1,0 +1,2 @@
+{{root_cert.content|b64decode}}
+{{intermediate_cert.content|b64decode}}


### PR DESCRIPTION
##### SUMMARY
The ansible workshops deployer has previously depended on the utilization of installing certbot via RPM package to provide the certbot certificate issuance utility, however, in order to do so, the EPEL repo needed to be enabled. Enabling EPEL provides the potential for conflicting packages with traditional Red Hat supported repositories. By switching to the use of podman w/ certbot via container image, the use of EPEL can be avoided.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner
