### PR TITLE
Introduction of Oracle Linux 7 instance to auto_satellite workshop.

### DIFF
--- a/provisioner/workshop_specific/auto_satellite.yml
+++ b/provisioner/workshop_specific/auto_satellite.yml
@@ -392,7 +392,7 @@
           register: workshop_job_templates02
           until: workshop_job_templates02.json.status == "successful"
           delay: 20  # Every 20 seconds
-          retries: 15  # 5 minutes 5*60/20
+          retries: 30  # 10 minutes 10*60/20
 
         - name: Run Z / SETUP / Workshop - CentOS7 deployment workflow template
           awx.awx.workflow_launch:

--- a/provisioner/workshop_specific/auto_satellite.yml
+++ b/provisioner/workshop_specific/auto_satellite.yml
@@ -394,13 +394,23 @@
           delay: 20  # Every 20 seconds
           retries: 15  # 5 minutes 5*60/20
 
-        - name: Run Z / SETUP / Workshop deployment workflow template
+        - name: Run Z / SETUP / Workshop - CentOS7 deployment workflow template
           awx.awx.workflow_launch:
-            workflow_template: "Z / SETUP / Workshop deployment"
+            workflow_template: "Z / SETUP / Workshop - CentOS7"
             controller_username: admin
             controller_password: "{{ admin_password }}"
             controller_host: "https://{{ student }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}"
             timeout: 3900 # 63 minutes
+          when: centos7 is defined
+
+        - name: Run Z / SETUP / Workshop - OL7 deployment workflow template
+          awx.awx.workflow_launch:
+            workflow_template: "Z / SETUP / Workshop - OL7"
+            controller_username: admin
+            controller_password: "{{ admin_password }}"
+            controller_host: "https://{{ student }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}"
+            timeout: 3900 # 63 minutes
+          when: ol7 is defined
 
     - name: Final workshop preparations - demo mode
       when: provision_mode == "demo"

--- a/roles/manage_ec2_instances/defaults/main/main.yml
+++ b/roles/manage_ec2_instances/defaults/main/main.yml
@@ -225,6 +225,20 @@ ec2_info:
     filter: 'CentOS*7*x86_64*'
     username: centos
     python_interpreter: '/usr/bin/python'
+  ol7:
+    owners: 131827586825
+    size:
+      - t3a.medium
+      - t2.medium
+    os_type: linux
+    disk_volume_type: gp3
+    disk_space: 10
+    disk_iops: 3000
+    disk_throughput: 125
+    architecture: x86_64
+    filter: 'OL7.9-x86_64-HVM-*'
+    username: ec2-user
+    python_interpreter: '/usr/bin/python'
   f5node:
     owners: 679593333241
     size:

--- a/roles/manage_ec2_instances/defaults/main/main.yml
+++ b/roles/manage_ec2_instances/defaults/main/main.yml
@@ -225,7 +225,7 @@ ec2_info:
     filter: 'CentOS*7*x86_64*'
     username: centos
     python_interpreter: '/usr/bin/python'
-  ol7:
+  ol79:
     owners: 131827586825
     size:
       - t3a.medium

--- a/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite.yml
+++ b/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite.yml
@@ -11,15 +11,6 @@
   include_tasks: ami_find_centos_7.yml
   when: (centos7 is defined) and (centos7 is not none)
 
-- name: find ami for satellite
-  ec2_ami_info:
-    region: "{{ ec2_region }}"
-    owners: "{{ ec2_info['satellite'].owners }}"
-    filters:
-      name: "{{ ec2_info['satellite'].filter }}"
-  register: sat_amis
-
-- name: save ami for satellite
-  set_fact:
-    sat_ami: >
-      {{ sat_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}
+- name: Retry loop for find ami for satellite
+  include_tasks: ami_find_auto_satellite_loop.yml
+...

--- a/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite.yml
+++ b/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite.yml
@@ -11,6 +11,10 @@
   include_tasks: ami_find_centos_7.yml
   when: (centos7 is defined) and (centos7 is not none)
 
+- name: find ami for oracle linux 7
+  include_tasks: ami_find_ol_7.yml
+  when: (ol7 is defined) and (ol7 is not none)
+
 - name: find ami for satellite
   ec2_ami_info:
     region: "{{ ec2_region }}"

--- a/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite_loop.yml
+++ b/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite_loop.yml
@@ -1,0 +1,45 @@
+---
+- name: Find ami for satellite Task Group
+  block:
+    - name: Increment retry count
+      ansible.builtin.set_fact:
+        ami_find_subtasks_retry_count: "{{ 0 if ami_find_subtasks_retry_count is undefined else ami_find_subtasks_retry_count | int + 1 }}"
+    # - name: Resume or reset for failed tasks after each failed attempt
+    #   ansible.builtin.include_tasks: some_other_task_resume_or_reset.yml
+    #   when: ami_find_subtasks_retry_count | int != 0
+    - ansible.builtin.debug:
+        msg: "retry count: {{ ami_find_subtasks_retry_count }}"
+
+    - name: Include increasing delay for incremental retries
+      ansible.builtin.command: |
+        python3 -c 'import time;time.sleep({{ ami_find_subtasks_retry_count | int *60 }})'
+      delegate_to: localhost
+      connection: local
+
+    - name: Find ami for satellite
+      amazon.aws.ec2_ami_info:
+        region: "{{ ec2_region }}"
+        owners: "{{ ec2_info['satellite'].owners }}"
+        filters:
+          name: "{{ ec2_info['satellite'].filter }}"
+      register: sat_amis
+
+    - name: Save ami for satellite
+      ansible.builtin.set_fact:
+        sat_ami: >
+          {{ sat_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}
+
+  rescue:
+    - name: Maximum retries of grouped tasks reached
+      ansible.builtin.fail:
+        msg: Maximum retries of grouped tasks reached.
+        # initial try plus 4 retries = 5 total tries
+      when: ami_find_subtasks_retry_count | int == 4
+
+    - name: Instrument retry count
+      ansible.builtin.debug:
+        msg: "Task fail retry count: {{ ami_find_subtasks_retry_count }}"
+
+    - name: Loop back via include on this file
+      ansible.builtin.include_tasks: ami_find_auto_satellite_loop.yml
+...

--- a/roles/manage_ec2_instances/tasks/ami_find/ami_find_ol_7.yml
+++ b/roles/manage_ec2_instances/tasks/ami_find/ami_find_ol_7.yml
@@ -1,0 +1,14 @@
+---
+- name: find ami for oracle linux 7 node
+  ec2_ami_info:
+    region: "{{ ec2_region }}"
+    owners: "{{ ec2_info[ol7].owners }}"
+    filters:
+      name: "{{ ec2_info[ol7].filter }}"
+      architecture: "{{ ec2_info[ol7].architecture }}"
+  register: amis
+
+- name: save ami for oracle linux 7 node
+  set_fact:
+    node_ami_ol7: >
+      {{ amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}

--- a/roles/manage_ec2_instances/tasks/instances/instances_auto_satellite.yml
+++ b/roles/manage_ec2_instances/tasks/instances/instances_auto_satellite.yml
@@ -62,6 +62,6 @@
 
 ## oracle linux 7 nodes for potential convert2rhel scenarios
 - name: provision aws oracle linux 7 instances
-  include_tasks: instances_os_7.yml
+  include_tasks: instances_ol_7.yml
   when: (ol7 is defined) and (ol7 is not none)
 ...

--- a/roles/manage_ec2_instances/tasks/instances/instances_auto_satellite.yml
+++ b/roles/manage_ec2_instances/tasks/instances/instances_auto_satellite.yml
@@ -59,4 +59,9 @@
 - name: provision aws centos 7 instances
   include_tasks: instances_centos_7.yml
   when: (centos7 is defined) and (centos7 is not none)
+
+## oracle linux 7 nodes for potential convert2rhel scenarios
+- name: provision aws oracle linux 7 instances
+  include_tasks: instances_os_7.yml
+  when: (ol7 is defined) and (ol7 is not none)
 ...

--- a/roles/manage_ec2_instances/tasks/instances/instances_ol_7.yml
+++ b/roles/manage_ec2_instances/tasks/instances/instances_ol_7.yml
@@ -1,0 +1,12 @@
+---
+- name: Oracle Linux 7 instance size list length
+  ansible.builtin.debug:
+    msg: "Oracle Linux 7 instance size list length: {{ ec2_info[ol7].size | length }}"
+
+- name: Initialize/reset list count
+  ansible.builtin.set_fact:
+    list_count: "reset"
+
+- name: Call Oracle Linux 7 retry tasks include
+  ansible.builtin.include_tasks: ol_7/ol_7_loop.yml
+...

--- a/roles/manage_ec2_instances/tasks/instances/ol_7/ol_7_instance_provision.yml
+++ b/roles/manage_ec2_instances/tasks/instances/ol_7/ol_7_instance_provision.yml
@@ -1,0 +1,234 @@
+---
+- name: Create EC2 instances for node4
+  amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
+    key_name: "{{ ec2_name_prefix }}-key"
+    security_group: "{{ ec2_security_group }}"
+    instance_type: "{{ ec2_info[ol7].size[list_count|int] }}"
+    image_id: "{{ node_ami_ol7.image_id }}"
+    region: "{{ ec2_region }}"
+    exact_count: "{{ student_total|int }}"
+    state: running
+    filters:
+      instance-state-name: running
+      "tag:Workshop_node4": "{{ ec2_name_prefix }}-node4"
+    tags:
+      Workshop_node4: "{{ ec2_name_prefix }}-node4"
+      Workshop: "{{ ec2_name_prefix }}"
+      uuid: "{{ ec2_name_prefix }}"
+      guid: "{{ ec2_name_prefix }}"
+      Workshop_type: "{{ workshop_type }}"
+      AWS_USERNAME: "{{ aws_user }}"
+      owner: "{{ aws_user }}"
+      Info: "AWS_USERNAME that provisioned this-> {{ aws_user }}"
+      Linklight: "This was provisioned through the linklight provisioner"
+      Students: "{{ student_total|int }}"
+      short_name: "node4"
+      username: "{{ ec2_info[ol7].username }}"
+      ansible-workshops: "true"
+    wait: "{{ ec2_wait }}"
+    vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
+    volumes:
+      - device_name: /dev/sda1
+        ebs:
+          volume_type: "{{ ec2_info[ol7].disk_volume_type }}"
+          volume_size: "{{ ec2_info[ol7].disk_space }}"
+          iops: "{{ ec2_info[ol7].disk_iops }}"
+          throughput: "{{ ec2_info[ol7].disk_throughput }}"
+          delete_on_termination: true
+
+- name: grab instance ids to tag node4
+  amazon.aws.ec2_instance_info:
+    region: "{{ ec2_region }}"
+    filters:
+      instance-state-name: running
+      "tag:Workshop_node4": "{{ ec2_name_prefix }}-node4"
+  register: node4_output
+
+- name: Ensure tags are present for node4
+  amazon.aws.ec2_tag:
+    region: "{{ ec2_region }}"
+    resource: "{{ item.1.instance_id }}"
+    state: present
+    tags:
+      Name: "{{ ec2_name_prefix }}-student{{ item.0 + 1 }}-node4"
+      Index: "{{ item[0] }}"
+      Student: "student{{ item.0 + 1 }}"
+      launch_time: "{{ item.1.launch_time }}"
+  with_indexed_items:
+    - "{{ node4_output.instances }}"
+  when: node4_output.instances|length > 0
+
+- name: Associate IAM instance profile with node4
+  amazon.aws.ec2_instance:
+    instance_ids: "{{ item.1.instance_id }}"
+    region: "{{ ec2_region }}"
+    instance_role: "VPCLockDown_{{ ec2_name_prefix }}_student{{ item.0 + 1 }}"
+    state: running
+    wait: true
+  with_indexed_items:
+    - "{{ node4_output.instances }}"
+  register: associate_iam_instance_profile
+  until: associate_iam_instance_profile is not failed
+  retries: 12
+  delay: 10
+  when:
+    - node4_output.instances|length > 0
+    - tower_node_aws_api_access|default(false)|bool
+
+- name: Create EC2 instances for node5
+  amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
+    key_name: "{{ ec2_name_prefix }}-key"
+    security_group: "{{ ec2_security_group }}"
+    instance_type: "{{ ec2_info[ol7].size[list_count|int] }}"
+    image_id: "{{ node_ami_ol7.image_id }}"
+    region: "{{ ec2_region }}"
+    exact_count: "{{ student_total|int }}"
+    state: running
+    filters:
+      instance-state-name: running
+      "tag:Workshop_node5": "{{ ec2_name_prefix }}-node5"
+    tags:
+      Workshop_node5: "{{ ec2_name_prefix }}-node5"
+      Workshop: "{{ ec2_name_prefix }}"
+      uuid: "{{ ec2_name_prefix }}"
+      guid: "{{ ec2_name_prefix }}"
+      Workshop_type: "{{ workshop_type }}"
+      AWS_USERNAME: "{{ aws_user }}"
+      owner: "{{ aws_user }}"
+      Info: "AWS_USERNAME that provisioned this-> {{ aws_user }}"
+      Linklight: "This was provisioned through the linklight provisioner"
+      Students: "{{ student_total|int }}"
+      short_name: "node5"
+      username: "{{ ec2_info[ol7].username }}"
+      ansible-workshops: "true"
+    wait: "{{ ec2_wait }}"
+    vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
+    volumes:
+      - device_name: /dev/sda1
+        ebs:
+          volume_type: "{{ ec2_info[ol7].disk_volume_type }}"
+          volume_size: "{{ ec2_info[ol7].disk_space }}"
+          iops: "{{ ec2_info[ol7].disk_iops }}"
+          throughput: "{{ ec2_info[ol7].disk_throughput }}"
+          delete_on_termination: true
+
+- name: grab instance ids to tag them all
+  amazon.aws.ec2_instance_info:
+    region: "{{ ec2_region }}"
+    filters:
+      instance-state-name: running
+      "tag:Workshop_node5": "{{ ec2_name_prefix }}-node5"
+  register: node5_output
+
+- name: Ensure tags are present for node5
+  amazon.aws.ec2_tag:
+    region: "{{ ec2_region }}"
+    resource: "{{ item.1.instance_id }}"
+    state: present
+    tags:
+      Name: "{{ ec2_name_prefix }}-student{{ item.0 + 1 }}-node5"
+      Index: "{{ item[0] }}"
+      Student: "student{{ item.0 + 1 }}"
+      launch_time: "{{ item.1.launch_time }}"
+  with_indexed_items:
+    - "{{ node5_output.instances }}"
+  when: node5_output.instances|length > 0
+
+- name: Associate IAM instance profile with node5
+  amazon.aws.ec2_instance:
+    instance_ids: "{{ item.1.instance_id }}"
+    region: "{{ ec2_region }}"
+    instance_role: "VPCLockDown_{{ ec2_name_prefix }}_student{{ item.0 + 1 }}"
+    state: running
+    wait: true
+  with_indexed_items:
+    - "{{ node5_output.instances }}"
+  register: associate_iam_instance_profile
+  until: associate_iam_instance_profile is not failed
+  retries: 12
+  delay: 10
+  when:
+    - node5_output.instances|length > 0
+    - tower_node_aws_api_access|default(false)|bool
+
+- name: Create EC2 instances for node6
+  amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
+    key_name: "{{ ec2_name_prefix }}-key"
+    security_group: "{{ ec2_security_group }}"
+    instance_type: "{{ ec2_info[ol7].size[list_count|int] }}"
+    image_id: "{{ node_ami_ol7.image_id }}"
+    region: "{{ ec2_region }}"
+    exact_count: "{{ student_total|int }}"
+    state: running
+    filters:
+      instance-state-name: running
+      "tag:Workshop_node6": "{{ ec2_name_prefix }}-node6"
+    tags:
+      Workshop_node6: "{{ ec2_name_prefix }}-node6"
+      Workshop: "{{ ec2_name_prefix }}"
+      uuid: "{{ ec2_name_prefix }}"
+      guid: "{{ ec2_name_prefix }}"
+      Workshop_type: "{{ workshop_type }}"
+      AWS_USERNAME: "{{ aws_user }}"
+      owner: "{{ aws_user }}"
+      Info: "AWS_USERNAME that provisioned this-> {{ aws_user }}"
+      Linklight: "This was provisioned through the linklight provisioner"
+      Students: "{{ student_total|int }}"
+      short_name: "node6"
+      username: "{{ ec2_info[ol7].username }}"
+      ansible-workshops: "true"
+    wait: "{{ ec2_wait }}"
+    vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
+    volumes:
+      - device_name: /dev/sda1
+        ebs:
+          volume_type: "{{ ec2_info[ol7].disk_volume_type }}"
+          volume_size: "{{ ec2_info[ol7].disk_space }}"
+          iops: "{{ ec2_info[ol7].disk_iops }}"
+          throughput: "{{ ec2_info[ol7].disk_throughput }}"
+          delete_on_termination: true
+
+- name: grab instance ids to tag node6
+  amazon.aws.ec2_instance_info:
+    region: "{{ ec2_region }}"
+    filters:
+      instance-state-name: running
+      "tag:Workshop_node6": "{{ ec2_name_prefix }}-node6"
+  register: node6_output
+
+- name: Ensure tags are present for node6
+  amazon.aws.ec2_tag:
+    region: "{{ ec2_region }}"
+    resource: "{{ item.1.instance_id }}"
+    state: present
+    tags:
+      Name: "{{ ec2_name_prefix }}-student{{ item.0 + 1 }}-node6"
+      Index: "{{ item[0] }}"
+      Student: "student{{ item.0 + 1 }}"
+      launch_time: "{{ item.1.launch_time }}"
+  with_indexed_items:
+    - "{{ node6_output.instances }}"
+  when: node6_output.instances|length > 0
+
+- name: Associate IAM instance profile with node6
+  amazon.aws.ec2_instance:
+    instance_ids: "{{ item.1.instance_id }}"
+    region: "{{ ec2_region }}"
+    instance_role: "VPCLockDown_{{ ec2_name_prefix }}_student{{ item.0 + 1 }}"
+    state: running
+    wait: true
+  with_indexed_items:
+    - "{{ node6_output.instances }}"
+  register: associate_iam_instance_profile
+  until: associate_iam_instance_profile is not failed
+  retries: 12
+  delay: 10
+  when:
+    - node6_output.instances|length > 0
+    - tower_node_aws_api_access|default(false)|bool

--- a/roles/manage_ec2_instances/tasks/instances/ol_7/ol_7_loop.yml
+++ b/roles/manage_ec2_instances/tasks/instances/ol_7/ol_7_loop.yml
@@ -1,0 +1,28 @@
+---
+- name: Multi instance size include block
+  block:
+    - name: Increment list count
+      ansible.builtin.set_fact:
+        list_count: "{{ 0 | int if list_count == 'reset' else list_count | int + 1 }}"
+    # - name: Resume or reset for failed tasks after each failed attempt
+    #   ansible.builtin.include_tasks: some_other_task_resume_or_reset.yml
+    #   when: list_count | int != 0
+    - ansible.builtin.debug:
+        msg: "list count: {{ list_count }}"
+
+    - name: Call instance provisioning tasks
+      ansible.builtin.include_tasks: ol_7_instance_provision.yml
+
+  rescue:
+    - name: All instance sizes attempted fail task via when
+      ansible.builtin.fail:
+        msg: All instance sizes attempted.
+      when: list_count | int == ( ec2_info['ol7']['size'] | length | int ) - 1
+
+    - name: Instrument list count
+      ansible.builtin.debug:
+        msg: "Task fail retry count: {{ list_count }}"
+
+    - name: Loop back via include on this file
+      ansible.builtin.include_tasks: ol_7_loop.yml
+...

--- a/roles/manage_ec2_instances/tasks/inventory/addhost_auto_satellite.yml
+++ b/roles/manage_ec2_instances/tasks/inventory/addhost_auto_satellite.yml
@@ -11,6 +11,10 @@
   include_tasks: addhost_centos_7.yml
   when: (centos7 is defined) and (centos7 is not none)
 
+- name: add oracle linux 7 hosts to inventory
+  include_tasks: addhost_ol_7.yml
+  when: (ol7 is defined) and (ol7 is not none)
+
 - name: grab facts for satellite node
   amazon.aws.ec2_instance_info:
     region: "{{ ec2_region }}"

--- a/roles/manage_ec2_instances/tasks/inventory/addhost_ol_7.yml
+++ b/roles/manage_ec2_instances/tasks/inventory/addhost_ol_7.yml
@@ -1,0 +1,42 @@
+---
+- name: grab facts for node4 node
+  amazon.aws.ec2_instance_info:
+    region: "{{ ec2_region }}"
+    filters:
+      instance-state-name: running
+      "tag:Workshop_node4": "{{ec2_name_prefix}}-node4"
+  register: node4_node_facts
+
+- name: grab facts for node5 node
+  amazon.aws.ec2_instance_info:
+    region: "{{ ec2_region }}"
+    filters:
+      instance-state-name: running
+      "tag:Workshop_node5": "{{ec2_name_prefix}}-node5"
+  register: node5_node_facts
+
+- name: grab facts for node6 node
+  amazon.aws.ec2_instance_info:
+    region: "{{ ec2_region }}"
+    filters:
+      instance-state-name: running
+      "tag:Workshop_node6": "{{ec2_name_prefix}}-node6"
+  register: node6_node_facts
+
+- name: add hosts to groups (ANSIBLE RHEL MODE)
+  add_host:
+    name: "{{ item.tags.Name }}"
+    username: "{{ student_user }}"
+    student: "{{ item.tags.Student }}"
+    short_name: "{{ item.tags.short_name }}"
+    ansible_host: "{{ item.public_ip_address }}"
+    private_ip: "{{ item.private_ip_address }}"
+    ansible_user: "{{ item.tags.username }}"
+    ansible_port: "{{ ssh_port }}"
+    ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    groups: lab_hosts,managed_nodes,ol7
+  with_items:
+    - "{{ node4_node_facts.instances }}"
+    - "{{ node5_node_facts.instances }}"
+    - "{{ node6_node_facts.instances }}"
+  changed_when: false

--- a/roles/manage_ec2_instances/templates/etchosts/etchosts_rhel.j2
+++ b/roles/manage_ec2_instances/templates/etchosts/etchosts_rhel.j2
@@ -55,6 +55,24 @@
 {% endfor %}
 {% endif %}
 
+{% if ol7 is defined %}
+{% for vm in node4_node_facts.instances %}
+{% if 'student' + item == vm.tags.Student %}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}.example.com {{ vm.tags.short_name }}
+{% endif %}
+{% endfor %}
+{% for vm in node5_node_facts.instances %}
+{% if 'student' + item == vm.tags.Student %}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}.example.com {{ vm.tags.short_name }}
+{% endif %}
+{% endfor %}
+{% for vm in node6_node_facts.instances %}
+{% if 'student' + item == vm.tags.Student %}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}.example.com {{ vm.tags.short_name }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
 {% if create_cluster %}
 {% for vm in isonode_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}

--- a/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_rhel.j2
+++ b/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_rhel.j2
@@ -26,6 +26,23 @@ ansible_ssh_private_key_file="{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_na
 {{host.tags.Student}}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }}
 {% endif %}
 {% endfor %}
+{% if ol7 is defined %}
+{% for host in node4_node_facts.instances %}
+{% if 'student' ~ number == host.tags.Student %}
+{{host.tags.Student}}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }}
+{% endif %}
+{% endfor %}
+{% for host in node5_node_facts.instances %}
+{% if 'student' ~ number == host.tags.Student %}
+{{host.tags.Student}}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }}
+{% endif %}
+{% endfor %}
+{% for host in node6_node_facts.instances %}
+{% if 'student' ~ number == host.tags.Student %}
+{{host.tags.Student}}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if centos7 is defined %}
 {% for host in node4_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}

--- a/roles/manage_ec2_instances/templates/student_inventory/instances_auto_satellite.j2
+++ b/roles/manage_ec2_instances/templates/student_inventory/instances_auto_satellite.j2
@@ -19,6 +19,23 @@ ansible_port={{ ssh_port }}
 {{ vm.tags.short_name }}.example.com ansible_host={{ vm.private_ip_address }}
 {% endif -%}
 {% endfor -%}
+{% if ol7 is defined -%}
+{% for vm in node4_node_facts.instances -%}
+{% if 'student' + item == vm.tags.Student -%}
+{{ vm.tags.short_name }}.example.com ansible_host={{ vm.private_ip_address }}
+{% endif -%}
+{% endfor -%}
+{% for vm in node5_node_facts.instances -%}
+{% if 'student' + item == vm.tags.Student -%}
+{{ vm.tags.short_name }}.example.com ansible_host={{ vm.private_ip_address }}
+{% endif -%}
+{% endfor -%}
+{% for vm in node6_node_facts.instances -%}
+{% if 'student' + item == vm.tags.Student -%}
+{{ vm.tags.short_name }}.example.com ansible_host={{ vm.private_ip_address }}
+{% endif -%}
+{% endfor -%}
+{% endif %}
 {% if centos7 is defined -%}
 {% for vm in node4_node_facts.instances -%}
 {% if 'student' + item == vm.tags.Student -%}

--- a/roles/populate_controller/tasks/auto_satellite.yml
+++ b/roles/populate_controller/tasks/auto_satellite.yml
@@ -124,7 +124,7 @@
         controller_username: "admin"
         controller_password: "{{ admin_password }}"
 
-    - name: Add centos devices to node group
+    - name: Add centos hosts to node group
       awx.awx.group:
         name: node
         inventory: "Workshop Inventory"
@@ -189,7 +189,7 @@
         controller_username: "admin"
         controller_password: "{{ admin_password }}"
 
-    - name: Add centos devices to node group
+    - name: Add oracle hosts to node group
       awx.awx.group:
         name: node
         inventory: "Workshop Inventory"
@@ -204,9 +204,9 @@
         controller_username: "admin"
         controller_password: "{{ admin_password }}"
 
-    - name: Add centos group
+    - name: Add ol group
       awx.awx.group:
-        name: centos
+        name: ol
         inventory: "Workshop Inventory"
         children:
           - ol7

--- a/roles/populate_controller/tasks/auto_satellite.yml
+++ b/roles/populate_controller/tasks/auto_satellite.yml
@@ -89,7 +89,6 @@
   register: add_group_rhel
   until: add_group_rhel is not failed
 
-
 - name: Block import centos7 servers
   when: centos7 is defined
   block:
@@ -146,6 +145,71 @@
         inventory: "Workshop Inventory"
         children:
           - centos7
+        preserve_existing_hosts: true
+        preserve_existing_children: true
+        variables:
+          ansible_user: "{{ auto_satellite_centos_node_username }}"
+        validate_certs: false
+        controller_host: "https://{{ ansible_host }}"
+        controller_username: "admin"
+        controller_password: "{{ admin_password }}"
+
+- name: Block import ol7 servers
+  when: ol7 is defined
+  block:
+    - name: Filter hosts containing student number
+      ansible.builtin.set_fact:
+        ol7_hosts: "{{ groups['ol7'] | select('search', 'student' ~ student_number ~ '-') | list }}"
+
+    - name: Add ol7 hosts into controller inventory
+      awx.awx.host:
+        name: "{{ hostvars[item].short_name }}.example.com"
+        enabled: true
+        inventory: "Workshop Inventory"
+        controller_username: admin
+        controller_password: "{{ admin_password }}"
+        controller_host: "https://{{ ansible_host }}"
+        validate_certs: false
+        variables:
+          ansible_host: "{{ hostvars[item].private_ip }}"
+      loop: "{{ ol7_hosts }}"
+
+    - name: Add ol7 group
+      awx.awx.group:
+        name: ol7
+        inventory: "Workshop Inventory"
+        hosts:
+          - node4.example.com
+          - node5.example.com
+          - node6.example.com
+        preserve_existing_hosts: true
+        preserve_existing_children: true
+        validate_certs: false
+        controller_host: "https://{{ ansible_host }}"
+        controller_username: "admin"
+        controller_password: "{{ admin_password }}"
+
+    - name: Add centos devices to node group
+      awx.awx.group:
+        name: node
+        inventory: "Workshop Inventory"
+        hosts:
+          - node4.example.com
+          - node5.example.com
+          - node6.example.com
+        preserve_existing_hosts: true
+        preserve_existing_children: true
+        validate_certs: false
+        controller_host: "https://{{ ansible_host }}"
+        controller_username: "admin"
+        controller_password: "{{ admin_password }}"
+
+    - name: Add centos group
+      awx.awx.group:
+        name: centos
+        inventory: "Workshop Inventory"
+        children:
+          - ol7
         preserve_existing_hosts: true
         preserve_existing_children: true
         variables:


### PR DESCRIPTION
##### SUMMARY
In addition to the CentOS7 instance types provided, requests have been increasingly common for the ability to utilize Oracle Linux 7 instances for conversion exercises. This PR introduces the capability to select either CentOS7 or OracleLinux7 instances for the auto_satellite workshop deployment.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
In order to utilize this new capability, when deploying the auto_satellite workshop, instead of defining centos instances as such:
`centos7: centos79`
...instead oracle instances would be defined as:
`ol7: ol79`