### PR TITLE
Update 12_controller.yml

### DIFF
--- a/roles/control_node/tasks/12_controller.yml
+++ b/roles/control_node/tasks/12_controller.yml
@@ -35,7 +35,7 @@
 
 - name: run the Automation Controller installer
   become: true
-  become_user: ec2-user
+  become_user: "{{ username }}"
   environment:
     ANSIBLE_COLLECTIONS_PATH: "{{ aap_dir }}/collections"
   shell: "{{ controller_install_command }}"


### PR DESCRIPTION
become_user is a var defined in role defaults allowing become_user to be adjusted if building an image in another cloud that doesn't use `ec2-user`

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #2141
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner
