### PR TITLE
Case Handling Inconsistency with upper case names

### DIFF
--- a/roles/manage_ec2_instances/tasks/resources/aws.yml
+++ b/roles/manage_ec2_instances/tasks/resources/aws.yml
@@ -14,9 +14,9 @@
 
 - name: Store SSH Key Pair
   amazon.aws.aws_s3:
-    bucket: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}.private"
+    bucket: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}.private"
     mode: put
-    object: "{{ec2_name_prefix}}-private.pem"
+    object: "{{ec2_name_prefix|lower}}-private.pem"
     src: "{{ playbook_dir }}/{{ ec2_name_prefix|lower }}/{{ ec2_name_prefix|lower }}-private.pem"
     encrypt: true
     region: "{{ ec2_region }}"
@@ -25,9 +25,9 @@
 
 - name: Save Private key from S3 Bucket when not generating it
   amazon.aws.aws_s3:
-    bucket: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}.private"
+    bucket: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}.private"
     mode: get
-    object: "{{ ec2_name_prefix }}-private.pem"
+    object: "{{ ec2_name_prefix|lower }}-private.pem"
     dest: "{{ playbook_dir }}/{{ ec2_name_prefix|lower }}/{{ ec2_name_prefix|lower }}-private.pem"
     encrypt: true
     region: "{{ ec2_region }}"


### PR DESCRIPTION

##### SUMMARY
When using capital letters in ec2_name_prefix (like "F5-TestDrive-Test"), provisioning fails because there are inconsistent uses of the |lower filter throughout the codebase, causing file path and resource name mismataches.

* Some tasks use ec2_name_prefix|lower and workshop_dns_zone|lower
* Other tasks use ec2_name_prefix and workshop_dns_zone without the filter
* This creates mismatched resource names and file paths

Fixes: #1948  