### PR TITLE
fix: allow ssh-rsa algorithm for Cisco network device connections

### DIFF
--- a/roles/control_node/templates/sshconfig.j2
+++ b/roles/control_node/templates/sshconfig.j2
@@ -1,3 +1,5 @@
 Host *
      StrictHostKeyChecking no
      User {{ ansible_user }}
+     PubkeyAcceptedAlgorithms +ssh-rsa
+     HostKeyAlgorithms +ssh-rsa

--- a/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_network.j2
+++ b/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_network.j2
@@ -25,7 +25,7 @@ ansible_ssh_private_key_file="{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_na
 {% endfor %}
 {% for host in rtr1_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{{ host.tags.Student }}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }} ansible_network_os={{ host.tags.ansible_network_os }} ansible_connection=network_cli
+{{ host.tags.Student }}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }} ansible_network_os={{ host.tags.ansible_network_os }} ansible_connection=network_cli ansible_libssh_publickey_algorithms=ssh-rsa
 {% endif %}
 {% endfor %}
 {% for host in rtr2_node_facts.instances %}

--- a/roles/manage_ec2_instances/templates/student_inventory/instances_network.j2
+++ b/roles/manage_ec2_instances/templates/student_inventory/instances_network.j2
@@ -52,6 +52,7 @@ arista
 [cisco:vars]
 ansible_network_os=ios
 ansible_connection=network_cli
+ansible_libssh_publickey_algorithms=ssh-rsa
 {% endif %}
 
 {% if network_type == "multivendor" or network_type == "juniper" %}


### PR DESCRIPTION
## Summary

- OpenSSH 8.8+ disables `ssh-rsa` by default, but Cisco IOS-XE/C8K devices require it for public key authentication
- Added `ansible_libssh_publickey_algorithms=ssh-rsa` to the `[cisco:vars]` section in the **student** inventory template (`instances_network.j2`)
- Added `ansible_libssh_publickey_algorithms=ssh-rsa` to Cisco router (rtr1) host entries in the **instructor** inventory template (`instructor_inventory_network.j2`)
- Added `PubkeyAcceptedAlgorithms +ssh-rsa` and `HostKeyAlgorithms +ssh-rsa` to the SSH config (`sshconfig.j2`) deployed to control nodes, so direct SSH to routers also works

## Error this fixes

```
fatal: [rtr1]: FAILED! => {"changed": false, "msg": "ssh connection failed: Failed to authenticate public key: The key algorithm 'ssh-rsa' is not allowed to be used by PUBLICKEY_ACCEPTED_TYPES configuration option"}
```

## Test plan

- [ ] Provision a network workshop and verify `ansible-navigator run playbook.yml --mode stdout` succeeds against Cisco rtr1
- [ ] Verify student can SSH directly to rtr1 from the control node

Made with [Cursor](https://cursor.com)