### PR TITLE
fix: use paramiko for Cisco SSH to avoid libssh ssh-rsa rejection

### DIFF
--- a/roles/manage_ec2_instances/tasks/inventory/addhost_network.yml
+++ b/roles/manage_ec2_instances/tasks/inventory/addhost_network.yml
@@ -40,8 +40,7 @@
     username: "{{ item.tags.Student }}"
     ansible_user: "{{ item.tags.username }}"
     ansible_port: "{{ ssh_port }}"
-    # https://github.com/ansible-collections/ansible.netcommon/pull/597
-    ansible_libssh_publickey_algorithms: "ssh-rsa"
+    ansible_network_cli_ssh_type: "paramiko"
     ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ ec2_name_prefix|lower }}/{{ ec2_name_prefix|lower }}-private.pem"
     private_ip: "{{ item.private_ip_address }}"
     ansible_network_os: "{{ item.tags.ansible_network_os }}"

--- a/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_network.j2
+++ b/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_network.j2
@@ -25,7 +25,7 @@ ansible_ssh_private_key_file="{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_na
 {% endfor %}
 {% for host in rtr1_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{{ host.tags.Student }}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }} ansible_network_os={{ host.tags.ansible_network_os }} ansible_connection=network_cli ansible_libssh_publickey_algorithms=ssh-rsa
+{{ host.tags.Student }}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }} ansible_network_os={{ host.tags.ansible_network_os }} ansible_connection=network_cli ansible_network_cli_ssh_type=paramiko
 {% endif %}
 {% endfor %}
 {% for host in rtr2_node_facts.instances %}

--- a/roles/manage_ec2_instances/templates/student_inventory/instances_network.j2
+++ b/roles/manage_ec2_instances/templates/student_inventory/instances_network.j2
@@ -52,7 +52,7 @@ arista
 [cisco:vars]
 ansible_network_os=ios
 ansible_connection=network_cli
-ansible_libssh_publickey_algorithms=ssh-rsa
+ansible_network_cli_ssh_type=paramiko
 {% endif %}
 
 {% if network_type == "multivendor" or network_type == "juniper" %}


### PR DESCRIPTION
## Summary

- The network EE's `ansible-pylibssh` does not honor `ansible_libssh_publickey_algorithms`, so the `ssh-rsa` algorithm is still rejected when connecting to Cisco IOS-XE devices
- Switches Cisco router connections to use `ansible_network_cli_ssh_type=paramiko` which handles `ssh-rsa` natively without needing algorithm overrides
- Applied to student inventory template, instructor inventory template, and provisioning add_host task

## Replaces

Supersedes the approach from #2355 (`ansible_libssh_publickey_algorithms`) which was confirmed not working with the current network EE

## Test plan

- [ ] Provision network workshop and verify `ansible-navigator run playbook.yml --mode stdout` succeeds against Cisco rtr1

Made with [Cursor](https://cursor.com)