### PR TITLE
fix: add paramiko ssh type for Cisco in AAP Controller inventory

### DIFF
--- a/roles/populate_controller/vars/network.yml
+++ b/roles/populate_controller/vars/network.yml
@@ -165,6 +165,7 @@ controller_groups:
     variables:
       ansible_network_os: ios
       ansible_connection: network_cli
+      ansible_network_cli_ssh_type: paramiko
   - name: arista
     inventory: "Workshop Inventory"
     variables:


### PR DESCRIPTION
## Summary

- The student/instructor inventories were fixed for paramiko in #2356, but the AAP Controller inventory group vars (`populate_controller/vars/network.yml`) were missed
- Adds `ansible_network_cli_ssh_type: paramiko` to the `cisco` group variables that get loaded into the Controller's "Workshop Inventory"
- Without this, AAP job templates (like the Network Report) still fail with `ssh-rsa` rejection from libssh

## Test plan

- [ ] Provision network workshop and run the Network Report job template from AAP Controller -- should succeed against rtr1

Made with [Cursor](https://cursor.com)