### PR TITLE
fix: use libssh publickey_algorithms instead of paramiko for Cisco SSH

### DIFF
--- a/roles/manage_ec2_instances/tasks/inventory/addhost_network.yml
+++ b/roles/manage_ec2_instances/tasks/inventory/addhost_network.yml
@@ -40,7 +40,7 @@
     username: "{{ item.tags.Student }}"
     ansible_user: "{{ item.tags.username }}"
     ansible_port: "{{ ssh_port }}"
-    ansible_network_cli_ssh_type: "paramiko"
+    ansible_libssh_publickey_algorithms: "ssh-rsa"
     ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ ec2_name_prefix|lower }}/{{ ec2_name_prefix|lower }}-private.pem"
     private_ip: "{{ item.private_ip_address }}"
     ansible_network_os: "{{ item.tags.ansible_network_os }}"

--- a/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_network.j2
+++ b/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_network.j2
@@ -25,7 +25,7 @@ ansible_ssh_private_key_file="{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_na
 {% endfor %}
 {% for host in rtr1_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{{ host.tags.Student }}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }} ansible_network_os={{ host.tags.ansible_network_os }} ansible_connection=network_cli ansible_network_cli_ssh_type=paramiko
+{{ host.tags.Student }}-{{ host.tags.short_name }} ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }} ansible_network_os={{ host.tags.ansible_network_os }} ansible_connection=network_cli ansible_libssh_publickey_algorithms=ssh-rsa
 {% endif %}
 {% endfor %}
 {% for host in rtr2_node_facts.instances %}

--- a/roles/manage_ec2_instances/templates/student_inventory/instances_network.j2
+++ b/roles/manage_ec2_instances/templates/student_inventory/instances_network.j2
@@ -52,7 +52,7 @@ arista
 [cisco:vars]
 ansible_network_os=ios
 ansible_connection=network_cli
-ansible_network_cli_ssh_type=paramiko
+ansible_libssh_publickey_algorithms=ssh-rsa
 {% endif %}
 
 {% if network_type == "multivendor" or network_type == "juniper" %}

--- a/roles/populate_controller/vars/network.yml
+++ b/roles/populate_controller/vars/network.yml
@@ -165,7 +165,7 @@ controller_groups:
     variables:
       ansible_network_os: ios
       ansible_connection: network_cli
-      ansible_network_cli_ssh_type: paramiko
+      ansible_libssh_publickey_algorithms: ssh-rsa
   - name: arista
     inventory: "Workshop Inventory"
     variables:


### PR DESCRIPTION
## Summary

- Paramiko worked from `ansible-navigator` but failed from AAP Controller with `key cannot be used for signing` due to how ansible-runner injects SSH credentials
- The new network EE (AAP 2.6 base, netcommon 8.1.0, pylibssh 1.4.0) supports `ansible_libssh_publickey_algorithms` which allows explicitly enabling `ssh-rsa` with the default libssh transport
- Switched all four inventory sources (student, instructor, provisioning add_host, Controller group vars) from `ansible_network_cli_ssh_type=paramiko` to `ansible_libssh_publickey_algorithms=ssh-rsa`
- This works in both ansible-navigator and AAP Controller contexts

## Test plan

- [ ] Run Network Report job template from AAP Controller -- should succeed against rtr1
- [ ] Run `ansible-navigator run playbook.yml --mode stdout` from control node -- should succeed against rtr1

Made with [Cursor](https://cursor.com)