### PR TITLE
fix: add libssh ssh-rsa config to project ansible.cfg for AAP

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,3 +7,5 @@ callback_enabled = timer, profile_tasks
 [persistent_connection]
 connect_timeout = 60
 command_timeout = 60
+[libssh_connection]
+publickey_algorithms = ssh-rsa


### PR DESCRIPTION
## Summary

- AAP uses the project-level `ansible.cfg` which overrides the EE's `/etc/ansible/ansible.cfg`
- The project `ansible.cfg` was missing the `[libssh_connection]` section, so the `publickey_algorithms = ssh-rsa` setting baked into the EE was never applied
- Added `[libssh_connection] publickey_algorithms = ssh-rsa` to the project root `ansible.cfg`

This is the actual fix for the Cisco ssh-rsa issue in AAP Controller jobs.

## Test plan

- [ ] Sync AAP project and re-run Network Report / Backup job template against rtr1

Made with [Cursor](https://cursor.com)