### PR TITLE
Change hosts from 'all' to 'web' in README

### DIFF
--- a/exercises/ansible_rhel/1.5-handlers/README.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.md
@@ -47,7 +47,7 @@ Let's add to the system_setup.yml playbook the ability to install the Apache HTT
 ```yaml
 ---
 - name: Basic System Setup
-  hosts: all
+  hosts: web
   become: true
   vars:
     user_name: 'Roger'
@@ -88,7 +88,7 @@ Let's say we want to ensure the firewall is configured correctly on all web serv
 ```yaml
 ---
 - name: Basic System Setup
-  hosts: all
+  hosts: web
   become: true
   vars:
     user_name: 'Roger'


### PR DESCRIPTION
Updated the hosts in the Basic System Setup playbook from 'all' to 'web'.

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change to the recommended playbooks that avoids errors in playbook execution that need to be explained to the audience. Fatal error - when trying to gather facts from host ansible-1

WHY? - this creates confusion and requires explanation by the presenter.
WHO? - impacts all users

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
