### PR TITLE
Remove 6-hour Windows workshop from lab catalog

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -369,29 +369,6 @@ patternfly: true
         </div>
       </a>
 
-      <a target="_blank" href="./exercises/ansible_windows" class="card-link" data-tags="6-hour,microsoft">
-        <div class="pf-v6-c-card">
-          <div class="pf-v6-c-card__header">
-            <span class="pf-v6-c-label pf-m-green">
-              <span class="pf-v6-c-label__content">
-                <i class="fas fa-clock pf-v6-c-label__icon"></i>
-                6時間
-              </span>
-            </span>
-          </div>
-          <div class="pf-v6-c-card__title">
-            <h3 class="pf-v6-c-card__title-text">Windows 自動化（終日版）</h3>
-          </div>
-          <div class="pf-v6-c-card__body">
-            Ansible Windows 自動化ワークショップ。Microsoft Windows の自動化を学びます。
-          </div>
-          <div class="pf-v6-c-card__footer">
-            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">Microsoft</span></span>
-            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP</span></span>
-          </div>
-        </div>
-      </a>
-
       <a target="_blank" href="./exercises/rhdp_auto_satellite" class="card-link" data-tags="6-hour">
         <div class="pf-v6-c-card">
           <div class="pf-v6-c-card__header">

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Visit the live site at [ansible.github.io/workshops](https://ansible.github.io/w
 |---|---|
 | [RHEL](./exercises/instruqt/rhel) | Ansible Red Hat Enterprise Linux Workshop |
 | [Network](./exercises/ansible_network) | Ansible Network Automation Workshop |
-| [Windows](./exercises/ansible_windows) | Ansible Windows Automation Workshop |
 | [Satellite](./exercises/rhdp_auto_satellite) | Ansible + Satellite Workshop |
 | [RIPU](./exercises/ansible_ripu) | RHEL In-place Upgrade Automation Workshop |
 

--- a/index.md
+++ b/index.md
@@ -369,29 +369,6 @@ patternfly: true
         </div>
       </a>
 
-      <a target="_blank" href="./exercises/ansible_windows" class="card-link" data-tags="6-hour,microsoft">
-        <div class="pf-v6-c-card">
-          <div class="pf-v6-c-card__header">
-            <span class="pf-v6-c-label pf-m-green">
-              <span class="pf-v6-c-label__content">
-                <i class="fas fa-clock pf-v6-c-label__icon"></i>
-                6-Hour
-              </span>
-            </span>
-          </div>
-          <div class="pf-v6-c-card__title">
-            <h3 class="pf-v6-c-card__title-text">Windows Automation (Full Day)</h3>
-          </div>
-          <div class="pf-v6-c-card__body">
-            Ansible Windows Automation Workshop. Focused on automation of Microsoft Windows.
-          </div>
-          <div class="pf-v6-c-card__footer">
-            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">Microsoft</span></span>
-            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP</span></span>
-          </div>
-        </div>
-      </a>
-
       <a target="_blank" href="./exercises/rhdp_auto_satellite" class="card-link" data-tags="6-hour">
         <div class="pf-v6-c-card">
           <div class="pf-v6-c-card__header">


### PR DESCRIPTION
## Summary
- Remove the full-day Windows Automation card from the lab index (`index.md` and Japanese catalog `README.ja.md`).
- Remove Windows from the **6 Hour Workshops** table in `README.md`.
- The 90-minute Windows workshop (`exercises/instruqt/windows`) remains on the catalog.

## Test plan
- [ ] Confirm GitHub Pages index no longer shows **Windows Automation (Full Day)** under 6-hour workshops.
- [ ] Confirm 90-minute Windows card still appears when filtering by Microsoft / 90-minute.

Made with [Cursor](https://cursor.com)