### PR TITLE
Sync Windows 90-min workshop page with The Source content

### DIFF
--- a/exercises/instruqt/windows.md
+++ b/exercises/instruqt/windows.md
@@ -18,6 +18,55 @@ Tasks in this lab include:
 > This workshop is also known as the Windows Automation Technical 90-min Workshop
 > 
 
+## Workshop Resources
+
+<table>
+<thead>
+<tr>
+<th>Resource</th>
+<th>Link</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Workshop content and exercises</td>
+<td><a target="_blank" href="https://labs.demoredhat.com/webpages/windows">labs.demoredhat.com/webpages/windows</a></td>
+</tr>
+<tr>
+<td>Follow-up assets</td>
+<td><a target="_blank" href="https://docs.google.com/spreadsheets/d/16bd2xZ8C8hYHV8BHWOA1AMRaJ56wEodmlIny6HViYaA/edit?usp=sharing">Follow-up assets spreadsheet</a></td>
+</tr>
+<tr>
+<td>Post-event survey</td>
+<td><a target="_blank" href="https://docs.google.com/document/d/1W_wTRhk9laLKRMBDRFoMW-XpOfOqQXFT5uUXdU4ogkI/edit?usp=sharing">Post-event survey</a></td>
+</tr>
+<tr>
+<td>Certain registration page &amp; promotional email copy</td>
+<td><a target="_blank" href="https://docs.google.com/document/d/1Pw6LQfdAZlvp_6HNYSVC5wWAGHgoj-H-pjPO0Lg36l0/edit?usp=sharing">Registration page &amp; promotional email copy</a></td>
+</tr>
+<tr>
+<td>Presenter instructions and guide</td>
+<td><a target="_blank" href="https://labs.demoredhat.com/webpages/windows">Presenter instructions and guide</a></td>
+</tr>
+<tr>
+<td>Certain event banners</td>
+<td><a target="_blank" href="https://drive.google.com/drive/folders/1hhXtRVDzJ2LybRF_PwSjkaxJIKuS6mnf?usp=sharing">Event banners (Google Drive)</a></td>
+</tr>
+</tbody>
+</table>
+
+## Target audience
+
+This workshop is geared toward Windows administrators, cloud administrators, DevOps engineers, security professionals, and anyone interested in Windows automation.
+
+## Attendee Prerequisites
+
+There is no student prep work required prior to the workshop.
+
+* All automation for this workshop is executed from Automation Controller and there are minimal client requirements for students to interact with the workshop such that students only need a compatible browser.
+* Must bring/use a laptop with Chrome 73+, Firefox 60+, Edge 40+, or Safari 12+ installed.
+* A basic understanding of [Visual Studio Code](https://code.visualstudio.com/). [Available for MacOS, Windows and Linux]
+
 ## Presentation Deck
 
 - [Google Slides](https://docs.google.com/presentation/d/1RO5CQiCoqLDES1NvTI_1fQrR-oWM1NuW-uB0JRvtJzE/edit?usp=sharing) - For Red Hat employees
@@ -28,38 +77,66 @@ Tasks in this lab include:
 <li><b>Slides: Introduction + Workshop Brief</b> [Estimated Time ⏱️ 15  minutes]<br>
 <a target="_blank" href="https://docs.google.com/presentation/d/1RO5CQiCoqLDES1NvTI_1fQrR-oWM1NuW-uB0JRvtJzE/edit?usp=sharing">[ 🖥️ Slides ]</a>
 </li><br>
-<li><b>Lab 1: Getting Started with Windows Automation</b> [Estimated Time ⏱️ 15 minutes]<br>
-<a target="_blank" href="https://catalog.demo.redhat.com/catalog/babylon-catalog-prod?search=windows+90&item=zt-ansiblebu.zt-ans-bu-windows90.prod">[ 🚀 Launch the lab ]</a>
-<ul><li>Exercise 1 - Configure Automation Controller
+<li><b>Lab: Ansible Automation With Windows</b> [Estimated Time ⏱️ 15 minutes]<br>
+<a target="_blank" href="https://catalog.demo.redhat.com/catalog?item=babylon-catalog-prod/zt-ansiblebu.zt-ans-bu-windows90.prod">[ 🚀 Start Exercise ]</a>
+<ul><li>Challenge 1 - Configure Automation Controller
 </li></ul>
 </li><br>
 <li><b>Slides: Brief for Challenge 2</b> [Estimated Time ⏱️ 5  minutes]<br>
-<i>Continue slides from above</i>
+<a target="_blank" href="https://docs.google.com/presentation/d/1RO5CQiCoqLDES1NvTI_1fQrR-oWM1NuW-uB0JRvtJzE/edit?usp=sharing">[ 🖥️ Slides ]</a>
 </li><br>
-<li><b>Lab 2: Ansible Automation with Windows</b> [Estimated Time ⏱️ 15 minutes]<br>
+<li><b>Lab: Ansible Automation With Windows</b> [Estimated Time ⏱️ 15 minutes]<br>
 <ul><li>Exercise 2 - Ad-hoc commands<br>
-<i>Continue from Lab linked above</i></li></ul>
+<i>Continue from lab linked above</i></li></ul>
 </li><br>
-<li><b>Slides: Brief for Challenge 3 and 4</b> [Estimated Time ⏱️ 15  minutes]<br>
-<i>Continue slides from above</i>
+<li><b>Slides: Brief for Challenge 3</b> [Estimated Time ⏱️ 15  minutes]<br>
+<a target="_blank" href="https://docs.google.com/presentation/d/1RO5CQiCoqLDES1NvTI_1fQrR-oWM1NuW-uB0JRvtJzE/edit?usp=sharing">[ 🖥️ Slides ]</a>
 </li><br>
-<li><b>Lab 3: Ansible Automation with Windows</b> [Estimated Time ⏱️ 15 minutes]<br>
-<i>Continue from Lab linked above</i>
+<li><b>Lab: Ansible Automation With Windows</b> [Estimated Time ⏱️ 25 minutes]<br>
+<i>Continue from lab linked above</i>
 <ul><li>Exercise 3 - Intro to playbooks</li>
 <li>Exercise 4 - Configure a job template</li></ul>
-<br>
-<li><b>Lab 4: Automating Windows Active Directory</b> [Estimated Time ⏱️ 30 minutes]<br>
-<i>See Red Hat for access</i>
-</li><br>  
+</li><br>
+<li><b>Wrap Up</b>
 </li>
 </ul>
+
+## Supplemental Exercises
+
+Total Time ~⏱️ 60 minutes
+
+If your students are ahead or you want to have a lab longer than 90 minutes there are two additional exercises (and corresponding slides already in the deck):
+
+<ul>
+<li><b>Slides: Brief for Challenge 5</b> [Estimated Time ⏱️ 10 minutes]<br>
+<a target="_blank" href="https://docs.google.com/presentation/d/1RO5CQiCoqLDES1NvTI_1fQrR-oWM1NuW-uB0JRvtJzE/edit?usp=sharing">[ 🖥️ Slides ]</a>
+</li><br>
+<li><b>Lab: Ansible Automation With Windows</b> [Estimated Time ⏱️ 15 minutes]<br>
+<ul><li>Exercise 5 - More advanced playbook<br>
+<i>Continue from lab linked above</i></li></ul>
+</li><br>
+<li><b>Slides: Brief for Challenge 6</b> [Estimated Time ⏱️ 5 minutes]<br>
+<a target="_blank" href="https://docs.google.com/presentation/d/1RO5CQiCoqLDES1NvTI_1fQrR-oWM1NuW-uB0JRvtJzE/edit?usp=sharing">[ 🖥️ Slides ]</a>
+</li><br>
+<li><b>Lab: Ansible Automation With Windows</b> [Estimated Time ⏱️ 25 minutes]<br>
+<ul><li>Exercise 6 - Ansible roles<br>
+<i>Continue from lab linked above</i></li></ul>
+</li><br>
+<li><b>Wrap Up</b>
+</li>
+</ul>
+
+## Lab provisioner
+
+This lab environment is available via the [Red Hat Demo Platform](https://catalog.demo.redhat.com/catalog) under the [Windows Automation Workshop (90min)](https://catalog.demo.redhat.com/catalog?item=babylon-catalog-prod/zt-ansiblebu.zt-ans-bu-windows90.prod) catalog item.
 
 # Learning Resources
 
 It is highly recommended to take the [Microsoft Windows Automation with Red Hat Ansible](https://www.redhat.com/en/services/training/do417-microsoft-windows-automation-red-hat-ansible) if you want additional training!
 
-Here is some additional collateral: 
+- [Red Hat Ansible Automation Platform - Training + Certification slides](https://docs.google.com/presentation/d/16pkh6Js89q7gR5VUILEQEU0mYRi6Ti98c9aRTcPOBVs/edit?usp=sharing)
 
+Here is some additional collateral: 
 
 <table>
 <thead>
@@ -72,22 +149,40 @@ Here is some additional collateral:
 </thead>
 <tbody>
 <tr>
+<td>Windows and Linux management with Ansible Automation Platform</td>
+<td>Video</td>
+<td><a target="_blank" href="https://youtu.be/xFVRgwG_B1s?si=xY9IfWApjaXXfG1R">YouTube</a></td>
+<td></td>
+</tr>
+<tr>
+<td>Event-Driven Ansible for Windows</td>
+<td>Video</td>
+<td><a target="_blank" href="https://youtu.be/0vQACe3shW0?si=QRZNG7cbMHk4uyUS">YouTube</a></td>
+<td></td>
+</tr>
+<tr>
+<td>Simplify your Microsoft Windows environment with automation</td>
+<td>Datasheet</td>
+<td></td>
+<td><a target="_blank" href="https://content.redhat.com/content/rhcc/us/en/assets/display.html?id=61073909-b1e9-4b58-b79c-f608e99dcc1d">Content Center</a></td>
+</tr>
+<tr>
 <td>Ansible on Windows for financial services</td>
 <td>Datasheet</td>
 <td><a target="_blank" href="https://www.redhat.com/en/resources/ansible-on-windows-financial-services-datasheet">on redhat.com</a></td>
-<td><a  target="_blank" href="https://content.redhat.com/content/rhcc/us/en/assets/display.html?id=729bb83a-0960-4285-9191-4a601f8a0707">Content Center</a></td>
+<td><a target="_blank" href="https://content.redhat.com/content/rhcc/us/en/assets/display.html?id=729bb83a-0960-4285-9191-4a601f8a0707">Content Center</a></td>
 </tr>
 <tr>
 <td>10 ways to automate Microsoft Windows with Red Hat Ansible</td>
 <td>Checklist</td>
 <td><a target="_blank" href="https://www.redhat.com/en/resources/ansible-automation-for-windows-checklist">on redhat.com</a></td>
-<td><a  target="_blank" href="https://content.redhat.com/content/rhcc/us/en/assets/display.html?id=1e38aff6-6fc3-4194-9fb6-947bd7a34ff6">Content Center</a></td>
+<td><a target="_blank" href="https://content.redhat.com/content/rhcc/us/en/assets/display.html?id=1e38aff6-6fc3-4194-9fb6-947bd7a34ff6">Content Center</a></td>
 </tr>
 <tr>
 <td>Standardization and automation</td>
 <td>Overview</td>
 <td><a target="_blank" href="https://www.redhat.com/en/resources/e3-standardization-automation-analyst-paper">on redhat.com</a></td>
-<td><a  target="_blank" href="https://content.redhat.com/content/rhcc/us/en/assets/display.html?id=521048dd-2ee3-435d-bdec-0484354184d4">Content Center</a></td>
+<td><a target="_blank" href="https://content.redhat.com/content/rhcc/us/en/assets/display.html?id=521048dd-2ee3-435d-bdec-0484354184d4">Content Center</a></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
## Summary
- Adds all workshop resources, links, and sections from [The Source Windows Automation Technical 90-min Workshop page](https://source.redhat.com/departments/marketing/global_gtm_campaigns/automation_wiki/windows_and_active_directory_automation_technical_90_min_workshop) to `exercises/instruqt/windows.md`
- Restores Workshop Resources table, target audience, attendee prerequisites, supplemental exercises, lab provisioner, training slides, and video/collateral links missing from the live labs.demoredhat.com page
- Aligns lab agenda with Source (slide links per challenge, Start Exercise catalog link, removes unpublished Lab 4 Active Directory section)


