### PR TITLE
Update dev-tools landing page to match workshop format

### DIFF
--- a/exercises/instruqt/dev-tools-extended.md
+++ b/exercises/instruqt/dev-tools-extended.md
@@ -1,0 +1,240 @@
+# Introduction to Ansible Development Tools
+
+> **IMPORTANT TO NOTE**
+>
+> This is the extended version of this workshop (~3 hours). For the shorter 2 hour session please [🔬 click here](dev-tools)
+>
+
+This comprehensive workshop covers the full Ansible content development lifecycle — from scaffolding a collection in VS Code, through writing and testing custom modules with Molecule, pytest-ansible, and tox-ansible, to building execution environments with ansible-builder and signing content with ansible-sign. The lab uses Red Hat OpenShift Dev Spaces as the development environment.
+
+After finishing this lab you are ready to start creating, testing, and distributing production-quality Ansible content.
+
+> **IMPORTANT TO NOTE:** This is NOT a deep dive, in the weeds, advanced workshop — it's an introduction.
+
+## Workshop Resources
+
+<table>
+<thead>
+<tr>
+<th>Resource</th>
+<th>Link</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Workshop content and exercises</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/index.html">rhpds.github.io/ansible-dev-tools-showroom</a></td>
+</tr>
+<tr>
+<td>Lab source repository</td>
+<td><a target="_blank" href="https://github.com/rhpds/ansible-dev-tools-showroom">github.com/rhpds/ansible-dev-tools-showroom</a></td>
+</tr>
+<tr>
+<td>Presenter instructions and guide</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/index.html">Presenter instructions and guide</a></td>
+</tr>
+</tbody>
+</table>
+
+## Who is this workshop best for?
+
+This workshop is the comprehensive version of the Ansible Development Tools workshop. For the condensed 2-hour introduction, see [Getting Started with Ansible Development Tools in VS Code](dev-tools). The intended audience is anyone who writes Ansible automation and wants to learn the full content development lifecycle — from scaffolding through testing, packaging, and signing. This workshop includes additional exercises on tox-ansible test orchestration that are not in the shorter version.
+
+## Target audience
+
+Ansible developers, automation engineers, DevOps engineers, platform engineers, systems administrators, and anyone interested in building and testing Ansible content.
+
+## Attendee Prerequisites
+
+* A basic understanding of working with Linux systems
+* A basic understanding of Ansible (playbooks, modules, roles)
+* A basic understanding of [Visual Studio Code](https://code.visualstudio.com/). [Available for MacOS, Windows and Linux]
+* Must bring/use a laptop with Chrome 73+, Firefox 60+, Edge 40+, or Safari 12+ installed
+
+There is no student prep work required prior to the workshop. It is recommended to complete the free Red Hat training course [Ansible Basics: Automation Technical Overview](https://www.redhat.com/en/services/training/do007-ansible-essentials-simplicity-automation-technical-overview).
+
+## Presentation Deck
+
+- [Google Slides](https://docs.google.com/presentation/d/1OLc0hNX_2EpfIkbeWaP_aH5dOAcA1YygXofJ0LPPxOE/edit?usp=sharing) - For Red Hat employees
+
+## Lab provisioner
+
+This lab environment is available via the [Red Hat Demo Platform](https://catalog.demo.redhat.com/catalog) under the [Introduction to Ansible Development Tools](https://catalog.demo.redhat.com/catalog/babylon-catalog-prod?item=babylon-catalog-prod/published.ansible-dev-tools.prod) catalog item.
+
+## Lab Index (Estimate total time ⏱️ 3 hours)
+
+### Introduction
+
+<table>
+<thead>
+<tr>
+<th>Activity</th>
+<th>Link</th>
+<th>Estimated Time</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><b>Slides</b>: Introduction + Workshop Brief</td>
+<td><a target="_blank" href="https://docs.google.com/presentation/d/1OLc0hNX_2EpfIkbeWaP_aH5dOAcA1YygXofJ0LPPxOE/edit?usp=sharing">🖥️ Google Slides</a></td>
+<td>⏱️ 10 minutes</td>
+</tr>
+<tr>
+<td>Exercise 0 — Introduction and environment setup</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/00-introduction.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 15 minutes</td>
+</tr>
+</tbody>
+</table>
+
+### Module 1 — Create
+
+<table>
+<thead>
+<tr>
+<th>Activity</th>
+<th>Link</th>
+<th>Estimated Time</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Exercise 1.1 — Creating a collection with the Ansible extension for VS Code</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/11-vscode-collection.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 10 minutes</td>
+</tr>
+<tr>
+<td>Exercise 1.2 — Using the Ansible development environment tool (ade)</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/12-ade.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 15 minutes</td>
+</tr>
+<tr>
+<td>Exercise 1.3 — Adding a module to a collection</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/13-module.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 15 minutes</td>
+</tr>
+</tbody>
+</table>
+
+☕ **Break** — ⏱️ 15 minutes
+
+### Module 2 — Test
+
+<table>
+<thead>
+<tr>
+<th>Activity</th>
+<th>Link</th>
+<th>Estimated Time</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Exercise 2.1 — Testing a collection with Ansible Molecule</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/21-molecule.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 20 minutes</td>
+</tr>
+<tr>
+<td>Exercise 2.2 — Functional testing with pytest-ansible</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/22-pytest-ansible.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 15 minutes</td>
+</tr>
+<tr>
+<td>Exercise 2.3 — Orchestrating tests with tox-ansible</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/23-tox-ansible.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 15 minutes</td>
+</tr>
+</tbody>
+</table>
+
+☕ **Break** — ⏱️ 15 minutes
+
+### Module 3 — Deploy
+
+<table>
+<thead>
+<tr>
+<th>Activity</th>
+<th>Link</th>
+<th>Estimated Time</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Exercise 3.1 — Creating an Execution Environment with ansible-builder</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/31-ansible-builder.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 20 minutes</td>
+</tr>
+<tr>
+<td>Exercise 3.2 — Introducing supply chain security with ansible-sign</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/32-ansible-sign.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 10 minutes</td>
+</tr>
+<tr>
+<td>Exercise — Workshop conclusion: What's next?</td>
+<td><a target="_blank" href="https://rhpds.github.io/ansible-dev-tools-showroom/modules/99-conclusion.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 5 minutes</td>
+</tr>
+<tr>
+<td><b>Slides</b>: Close Out &amp; Q&amp;A</td>
+<td><a target="_blank" href="https://docs.google.com/presentation/d/1OLc0hNX_2EpfIkbeWaP_aH5dOAcA1YygXofJ0LPPxOE/edit?usp=sharing">🖥️ Google Slides</a></td>
+<td>⏱️ 5 minutes</td>
+</tr>
+</tbody>
+</table>
+
+## Demos
+
+Any of the individual labs (that make up the workshop) can be used as a standalone demo.
+
+# Learning Resources
+
+- [Red Hat Ansible Automation Platform - Training + Certification slides](https://docs.google.com/presentation/d/16pkh6Js89q7gR5VUILEQEU0mYRi6Ti98c9aRTcPOBVs/edit?usp=sharing)
+
+## Documentation
+
+- [How to contribute](https://github.com/ansible/workshops)
+- [FAQ](https://github.com/ansible/workshops)
+
+# Going Further
+
+Additional material for Ansible Development Tools
+
+<table>
+<thead>
+<tr>
+<th>Title</th>
+<th>Type</th>
+<th>Link</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Ansible Automation Platform Self-Paced Labs</td>
+<td>Interactive labs</td>
+<td><a target="_blank" href="https://red.ht/ansible-labs">🔬 Self-Paced Labs</a></td>
+</tr>
+<tr>
+<td>Red Hat Training and Certification for AAP</td>
+<td>Training</td>
+<td><a target="_blank" href="https://red.ht/aap_training">📖 Training Catalog</a></td>
+</tr>
+<tr>
+<td>Get a Trial Subscription for AAP</td>
+<td>Trial</td>
+<td><a target="_blank" href="http://red.ht/try_ansible">🧪 Start Trial</a></td>
+</tr>
+</tbody>
+</table>
+
+<br>
+
+# Ansible Workshop
+
+This is an official Ansible Workshop
+
+This workshop is maintained by the Red Hat Ansible Technical Marketing Team.  
+Please open an [issues on Github](https://github.com/ansible/instruqt/issues/new?title=New+dev-tools+extended+workshop+issue&body=)
+
+
+![ansible workshop logo](https://github.com/ansible/workshops/blob/devel/images/Ansible-Workshop-Logo.png?raw=true)

--- a/exercises/instruqt/dev-tools.md
+++ b/exercises/instruqt/dev-tools.md
@@ -1,64 +1,180 @@
-# Writing Automation with Ansible Development Tools in VS Code
+# Getting Started with Ansible Development Tools in VS Code
 
-Writing automation with Ansible development tools in Visual Studio Code.
+This hands-on workshop teaches you to create, test, and package Ansible content using the full suite of Ansible development tools inside Visual Studio Code. You'll scaffold a collection, write a custom module, lint and test your automation with Molecule and pytest-ansible, build an execution environment, and sign your content for supply-chain security.
 
-## Lab Options
+> **IMPORTANT TO NOTE:** This is NOT a deep dive, in the weeds, advanced workshop — it's an introduction.
+
+## Workshop Resources
 
 <table>
 <thead>
 <tr>
-<th>Option</th>
+<th>Resource</th>
 <th>Link</th>
-<th>Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>Launch on RHDP</td>
-<td><a target="_blank" href="https://catalog.demo.redhat.com/catalog?item=babylon-catalog-prod/zt-ansiblebu.zt-ans-bu-dev-tools.prod">🚀 Launch Lab</a></td>
-<td>Provision a full lab environment on the Red Hat Demo Platform</td>
+<td>Workshop content and exercises</td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/index.html">rhpds.github.io/zt-ans-bu-dev-tools</a></td>
 </tr>
 <tr>
-<td>View Instructions</td>
-<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/index.html">📖 View Showroom</a></td>
-<td>Browse the lab instructions and exercises</td>
+<td>Lab source repository</td>
+<td><a target="_blank" href="https://github.com/rhpds/zt-ans-bu-dev-tools/tree/v0.0.2">github.com/rhpds/zt-ans-bu-dev-tools</a></td>
+</tr>
+<tr>
+<td>Presenter instructions and guide</td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/index.html">Presenter instructions and guide</a></td>
 </tr>
 </tbody>
 </table>
 
-## Exercises
+## Who is this workshop best for?
+
+This workshop is intended for people who want to learn how to create, test, and distribute Ansible content using the latest development tools. Whether you're building your first collection or looking to adopt modern testing and packaging workflows, this workshop will walk you through the developer experience end-to-end. The intended audience is anyone who writes Ansible automation and wants to adopt best practices for content development.
+
+## Target audience
+
+Ansible developers, automation engineers, DevOps engineers, platform engineers, systems administrators, and anyone interested in building and testing Ansible content.
+
+## Attendee Prerequisites
+
+* A basic understanding of working with Linux systems
+* A basic understanding of Ansible (playbooks, modules, roles)
+* A basic understanding of [Visual Studio Code](https://code.visualstudio.com/). [Available for MacOS, Windows and Linux]
+* Must bring/use a laptop with Chrome 73+, Firefox 60+, Edge 40+, or Safari 12+ installed
+
+There is no student prep work required prior to the workshop. It is recommended to complete the free Red Hat training course [Ansible Basics: Automation Technical Overview](https://www.redhat.com/en/services/training/do007-ansible-essentials-simplicity-automation-technical-overview).
+
+## Presentation Deck
+
+- [Google Slides](https://docs.google.com/presentation/d/1OLc0hNX_2EpfIkbeWaP_aH5dOAcA1YygXofJ0LPPxOE/edit?usp=sharing) - For Red Hat employees
+
+## Lab provisioner
+
+This lab environment is available via the [Red Hat Demo Platform](https://catalog.demo.redhat.com/catalog) under the [Getting Started with Ansible Development Tools](https://catalog.demo.redhat.com/catalog?item=babylon-catalog-prod/zt-ansiblebu.zt-ans-bu-dev-tools.prod) catalog item.
+
+## Lab Index (Estimate total time ⏱️ 2 hours)
 
 <table>
 <thead>
 <tr>
-<th>Exercise</th>
+<th>Activity</th>
 <th>Link</th>
+<th>Estimated Time</th>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td><b>Slides</b>: Introduction + Workshop Brief</td>
+<td><a target="_blank" href="https://docs.google.com/presentation/d/1OLc0hNX_2EpfIkbeWaP_aH5dOAcA1YygXofJ0LPPxOE/edit?usp=sharing">🖥️ Google Slides</a></td>
+<td>⏱️ 10 minutes</td>
+</tr>
 <tr>
 <td>Exercise 1 — Workshop tips</td>
 <td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-01.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 5 minutes</td>
 </tr>
 <tr>
 <td>Exercise 2 — Creating a collection with the Ansible extension for VS Code</td>
-<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-02.html">🚀 Launch Exercise</a></td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-02-collection.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 10 minutes</td>
 </tr>
 <tr>
 <td>Exercise 3 — Using Ansible development environment</td>
-<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-03.html">🚀 Launch Exercise</a></td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-03-ade.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 10 minutes</td>
 </tr>
 <tr>
 <td>Exercise 4 — Adding a module to our collection</td>
-<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-04.html">🚀 Launch Exercise</a></td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-04-module.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 10 minutes</td>
 </tr>
 <tr>
 <td>Exercise 5 — Testing our collection with Molecule</td>
-<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-05.html">🚀 Launch Exercise</a></td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-05-molecule.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 15 minutes</td>
 </tr>
 <tr>
-<td>Exercise 6 — What's next</td>
-<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-06.html">🚀 Launch Exercise</a></td>
+<td>Exercise 6 — Functional testing with pytest-ansible</td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-06-pytest.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 10 minutes</td>
+</tr>
+<tr>
+<td>Exercise 7 — Creating an Execution Environment with ansible-builder</td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-08-builder.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 15 minutes</td>
+</tr>
+<tr>
+<td>Exercise 8 — Introducing supply chain security with ansible-sign</td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-09-sign.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 10 minutes</td>
+</tr>
+<tr>
+<td>Exercise 9 — What's next?</td>
+<td><a target="_blank" href="https://rhpds.github.io/zt-ans-bu-dev-tools/modules/module-10.html">🚀 Launch Exercise</a></td>
+<td>⏱️ 5 minutes</td>
+</tr>
+<tr>
+<td><b>Slides</b>: Close Out &amp; Q&amp;A</td>
+<td><a target="_blank" href="https://docs.google.com/presentation/d/1OLc0hNX_2EpfIkbeWaP_aH5dOAcA1YygXofJ0LPPxOE/edit?usp=sharing">🖥️ Google Slides</a></td>
+<td>⏱️ 5 minutes</td>
 </tr>
 </tbody>
 </table>
+
+## Demos
+
+Any of the individual labs (that make up the workshop) can be used as a standalone demo.
+
+# Learning Resources
+
+- [Red Hat Ansible Automation Platform - Training + Certification slides](https://docs.google.com/presentation/d/16pkh6Js89q7gR5VUILEQEU0mYRi6Ti98c9aRTcPOBVs/edit?usp=sharing)
+
+## Documentation
+
+- [How to contribute](https://github.com/ansible/workshops)
+- [FAQ](https://github.com/ansible/workshops)
+
+# Going Further
+
+Additional material for Ansible Development Tools
+
+<table>
+<thead>
+<tr>
+<th>Title</th>
+<th>Type</th>
+<th>Link</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Ansible Automation Platform Self-Paced Labs</td>
+<td>Interactive labs</td>
+<td><a target="_blank" href="https://red.ht/ansible-labs">🔬 Self-Paced Labs</a></td>
+</tr>
+<tr>
+<td>Red Hat Training and Certification for AAP</td>
+<td>Training</td>
+<td><a target="_blank" href="https://red.ht/aap_training">📖 Training Catalog</a></td>
+</tr>
+<tr>
+<td>Get a Trial Subscription for AAP</td>
+<td>Trial</td>
+<td><a target="_blank" href="http://red.ht/try_ansible">🧪 Start Trial</a></td>
+</tr>
+</tbody>
+</table>
+
+<br>
+
+# Ansible Workshop
+
+This is an official Ansible Workshop
+
+This workshop is maintained by the Red Hat Ansible Technical Marketing Team.  
+Please open an [issues on Github](https://github.com/ansible/instruqt/issues/new?title=New+dev-tools+workshop+issue&body=)
+
+
+![ansible workshop logo](https://github.com/ansible/workshops/blob/devel/images/Ansible-Workshop-Logo.png?raw=true)

--- a/exercises/instruqt/dev-tools.md
+++ b/exercises/instruqt/dev-tools.md
@@ -1,5 +1,10 @@
 # Getting Started with Ansible Development Tools in VS Code
 
+> **IMPORTANT TO NOTE**
+>
+> This is the shorter version of this workshop (~2 hours). For the extended session please [🔬 click here](dev-tools-extended)
+>
+
 This hands-on workshop teaches you to create, test, and package Ansible content using the full suite of Ansible development tools inside Visual Studio Code. You'll scaffold a collection, write a custom module, lint and test your automation with Molecule and pytest-ansible, build an execution environment, and sign your content for supply-chain security.
 
 > **IMPORTANT TO NOTE:** This is NOT a deep dive, in the weeds, advanced workshop — it's an introduction.

--- a/index.md
+++ b/index.md
@@ -813,18 +813,41 @@ patternfly: true
             <span class="pf-v6-c-label pf-m-purple">
               <span class="pf-v6-c-label__content">
                 <i class="fas fa-clock pf-v6-c-label__icon"></i>
-                60-90 Min
+                2-Hour
               </span>
             </span>
           </div>
           <div class="pf-v6-c-card__title">
-            <h3 class="pf-v6-c-card__title-text">Writing automation with Ansible development tools in VS Code</h3>
+            <h3 class="pf-v6-c-card__title-text">Ansible Development Tools in VS Code</h3>
           </div>
           <div class="pf-v6-c-card__body">
-            Writing automation with Ansible development tools in Visual Studio Code.
+            Condensed workshop for creating, testing, and packaging Ansible content with development tools in VS Code.
           </div>
           <div class="pf-v6-c-card__footer">
             <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP Zero</span></span>
+            <span class="pf-v6-c-label pf-m-outline pf-m-compact pf-m-blue"><span class="pf-v6-c-label__content">Workshop</span></span>
+          </div>
+        </div>
+      </a>
+
+      <a href="./exercises/instruqt/dev-tools-extended" class="card-link" data-tags="developer,workshop,lab,2plushours,tmm">
+        <div class="pf-v6-c-card">
+          <div class="pf-v6-c-card__header">
+            <span class="pf-v6-c-label pf-m-green">
+              <span class="pf-v6-c-label__content">
+                <i class="fas fa-clock pf-v6-c-label__icon"></i>
+                3-Hour
+              </span>
+            </span>
+          </div>
+          <div class="pf-v6-c-card__title">
+            <h3 class="pf-v6-c-card__title-text">Introduction to Ansible Development Tools</h3>
+          </div>
+          <div class="pf-v6-c-card__body">
+            Comprehensive workshop covering the full Ansible content development lifecycle with OpenShift Dev Spaces.
+          </div>
+          <div class="pf-v6-c-card__footer">
+            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP</span></span>
             <span class="pf-v6-c-label pf-m-outline pf-m-compact pf-m-blue"><span class="pf-v6-c-label__content">Workshop</span></span>
           </div>
         </div>

--- a/index.md
+++ b/index.md
@@ -457,28 +457,6 @@ patternfly: true
         </div>
       </a>
 
-      <a href="./exercises/instruqt/ansible-navigator" class="card-link" data-tags="general,lab,under60min,tmm">
-        <div class="pf-v6-c-card">
-          <div class="pf-v6-c-card__header">
-            <span class="pf-v6-c-label pf-m-cyan">
-              <span class="pf-v6-c-label__content">
-                <i class="fas fa-clock pf-v6-c-label__icon"></i>
-                Under 60 Min
-              </span>
-            </span>
-          </div>
-          <div class="pf-v6-c-card__title">
-            <h3 class="pf-v6-c-card__title-text">Get Started ansible-navigator</h3>
-          </div>
-          <div class="pf-v6-c-card__body">
-            Get started with ansible-navigator for running and developing Ansible content.
-          </div>
-          <div class="pf-v6-c-card__footer">
-            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP Zero</span></span>
-          </div>
-        </div>
-      </a>
-
       <a href="./exercises/instruqt/automation-controller" class="card-link" data-tags="general,lab,2plushours,tmm">
         <div class="pf-v6-c-card">
           <div class="pf-v6-c-card__header">
@@ -741,46 +719,48 @@ patternfly: true
         <h2 class="cards-section__heading">Developer</h2>
         <div class="pf-v6-l-gallery pf-m-gutter cards-gallery">
 
-      <a target="_blank" href="https://catalog.demo.redhat.com/catalog?search=ansible&item=babylon-catalog-prod%2Fsandboxes-gpte.rhdh-ansible-demo.prod" class="card-link" data-tags="developer,lab,under60min,tmm">
+      <a href="./exercises/instruqt/dev-tools" class="card-link" data-tags="developer,workshop,lab,60to90min,tmm">
         <div class="pf-v6-c-card">
           <div class="pf-v6-c-card__header">
-            <span class="pf-v6-c-label pf-m-cyan">
+            <span class="pf-v6-c-label pf-m-purple">
               <span class="pf-v6-c-label__content">
                 <i class="fas fa-clock pf-v6-c-label__icon"></i>
-                Under 60 Min
+                2-Hour
               </span>
             </span>
           </div>
           <div class="pf-v6-c-card__title">
-            <h3 class="pf-v6-c-card__title-text">Ansible Plug-ins for Red Hat Developer Hub Demo</h3>
+            <h3 class="pf-v6-c-card__title-text">Ansible Development Tools Workshop</h3>
           </div>
           <div class="pf-v6-c-card__body">
-            Ansible plug-ins for Red Hat Developer Hub demo environment.
+            Create, test, and package Ansible collections using the DevTools suite in a pre-provisioned VS Code environment.
           </div>
           <div class="pf-v6-c-card__footer">
-            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP</span></span>
+            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP Zero</span></span>
+            <span class="pf-v6-c-label pf-m-outline pf-m-compact pf-m-blue"><span class="pf-v6-c-label__content">Workshop</span></span>
           </div>
         </div>
       </a>
 
-      <a href="./exercises/instruqt/ansible-builder" class="card-link" data-tags="developer,lab,under60min,tmm">
+      <a href="./exercises/instruqt/dev-tools-extended" class="card-link" data-tags="developer,workshop,lab,2plushours,tmm">
         <div class="pf-v6-c-card">
           <div class="pf-v6-c-card__header">
-            <span class="pf-v6-c-label pf-m-cyan">
+            <span class="pf-v6-c-label pf-m-green">
               <span class="pf-v6-c-label__content">
                 <i class="fas fa-clock pf-v6-c-label__icon"></i>
-                Under 60 Min
+                3-Hour
               </span>
             </span>
           </div>
           <div class="pf-v6-c-card__title">
-            <h3 class="pf-v6-c-card__title-text">Get started with ansible-builder</h3>
+            <h3 class="pf-v6-c-card__title-text">Ansible Development Tools Workshop (Extended)</h3>
           </div>
           <div class="pf-v6-c-card__body">
-            Get started with ansible-builder for creating custom execution environments.
+            Full DevTools lifecycle using Ansible Workspaces on OpenShift Dev Spaces — create, test, and deploy automation content with the complete ansible-dev-tools suite and VS Code.
           </div>
           <div class="pf-v6-c-card__footer">
-            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP Zero</span></span>
+            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP</span></span>
+            <span class="pf-v6-c-label pf-m-outline pf-m-compact pf-m-blue"><span class="pf-v6-c-label__content">Workshop</span></span>
           </div>
         </div>
       </a>
@@ -807,48 +787,68 @@ patternfly: true
         </div>
       </a>
 
-      <a href="./exercises/instruqt/dev-tools" class="card-link" data-tags="developer,workshop,lab,60to90min,tmm">
+      <a href="./exercises/instruqt/ansible-navigator" class="card-link" data-tags="developer,lab,under60min,tmm">
         <div class="pf-v6-c-card">
           <div class="pf-v6-c-card__header">
-            <span class="pf-v6-c-label pf-m-purple">
+            <span class="pf-v6-c-label pf-m-cyan">
               <span class="pf-v6-c-label__content">
                 <i class="fas fa-clock pf-v6-c-label__icon"></i>
-                2-Hour
+                Under 60 Min
               </span>
             </span>
           </div>
           <div class="pf-v6-c-card__title">
-            <h3 class="pf-v6-c-card__title-text">Ansible Development Tools in VS Code</h3>
+            <h3 class="pf-v6-c-card__title-text">Get Started ansible-navigator</h3>
           </div>
           <div class="pf-v6-c-card__body">
-            Condensed workshop for creating, testing, and packaging Ansible content with development tools in VS Code.
+            Get started with ansible-navigator for running and developing Ansible content.
           </div>
           <div class="pf-v6-c-card__footer">
             <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP Zero</span></span>
-            <span class="pf-v6-c-label pf-m-outline pf-m-compact pf-m-blue"><span class="pf-v6-c-label__content">Workshop</span></span>
           </div>
         </div>
       </a>
 
-      <a href="./exercises/instruqt/dev-tools-extended" class="card-link" data-tags="developer,workshop,lab,2plushours,tmm">
+      <a href="./exercises/instruqt/ansible-builder" class="card-link" data-tags="developer,lab,under60min,tmm">
         <div class="pf-v6-c-card">
           <div class="pf-v6-c-card__header">
-            <span class="pf-v6-c-label pf-m-green">
+            <span class="pf-v6-c-label pf-m-cyan">
               <span class="pf-v6-c-label__content">
                 <i class="fas fa-clock pf-v6-c-label__icon"></i>
-                3-Hour
+                Under 60 Min
               </span>
             </span>
           </div>
           <div class="pf-v6-c-card__title">
-            <h3 class="pf-v6-c-card__title-text">Introduction to Ansible Development Tools</h3>
+            <h3 class="pf-v6-c-card__title-text">Get started with ansible-builder</h3>
           </div>
           <div class="pf-v6-c-card__body">
-            Comprehensive workshop covering the full Ansible content development lifecycle with OpenShift Dev Spaces.
+            Get started with ansible-builder for creating custom execution environments.
+          </div>
+          <div class="pf-v6-c-card__footer">
+            <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP Zero</span></span>
+          </div>
+        </div>
+      </a>
+
+      <a target="_blank" href="https://catalog.demo.redhat.com/catalog?search=ansible&item=babylon-catalog-prod%2Fsandboxes-gpte.rhdh-ansible-demo.prod" class="card-link" data-tags="developer,lab,under60min,tmm">
+        <div class="pf-v6-c-card">
+          <div class="pf-v6-c-card__header">
+            <span class="pf-v6-c-label pf-m-cyan">
+              <span class="pf-v6-c-label__content">
+                <i class="fas fa-clock pf-v6-c-label__icon"></i>
+                Under 60 Min
+              </span>
+            </span>
+          </div>
+          <div class="pf-v6-c-card__title">
+            <h3 class="pf-v6-c-card__title-text">Ansible Plug-ins for Red Hat Developer Hub Demo</h3>
+          </div>
+          <div class="pf-v6-c-card__body">
+            Ansible plug-ins for Red Hat Developer Hub demo environment.
           </div>
           <div class="pf-v6-c-card__footer">
             <span class="pf-v6-c-label pf-m-outline pf-m-compact"><span class="pf-v6-c-label__content">RHDP</span></span>
-            <span class="pf-v6-c-label pf-m-outline pf-m-compact pf-m-blue"><span class="pf-v6-c-label__content">Workshop</span></span>
           </div>
         </div>
       </a>


### PR DESCRIPTION
## Summary

- Restructure `exercises/instruqt/dev-tools.md` to follow the same format as `network-6.md` and `rhel-90.md` landing pages
- Add workshop description, "Who is this for", target audience, prerequisites, presentation deck, and lab provisioner sections
- Update exercise list from 6 to 9 exercises matching the current lab content on the [zt-ans-bu-dev-tools v0.0.2 branch](https://github.com/rhpds/zt-ans-bu-dev-tools/tree/v0.0.2)
- Add estimated times per exercise (total ~2 hours)
- Add lab source repository link, learning resources, and going further sections

## Test plan

- [ ] Verify all showroom exercise links resolve once GitHub Pages is rebuilt for the dev-tools lab repo
- [ ] Verify RHDP catalog link works
- [ ] Verify Google Slides presentation deck link works
- [ ] Review exercise titles and time estimates against actual lab content

Assisted-by: Claude Opus 4.6